### PR TITLE
Using proper method for .Net standard 2.0

### DIFF
--- a/src/protobuf-net.Grpc/Internal/ProxyEmitter.cs
+++ b/src/protobuf-net.Grpc/Internal/ProxyEmitter.cs
@@ -243,7 +243,7 @@ namespace ProtoBuf.Grpc.Internal
                 cctor.Emit(OpCodes.Ret); // end the type initializer (after creating all the field types)
 
 #if NETSTANDARD2_0
-                var finalType = type.AsType()!;
+                var finalType = type.CreateTypeInfo()!;
 #else
                 var finalType = type.CreateType()!;
 #endif


### PR DESCRIPTION
This prevents following exception in client when you try to use .net standard 2.0 version of library:
```
Unhandled Exception: System.TypeInitializationException: The type initializer for 'DefaultProxyCache`3' threw an exception. ---> System.NotSupportedException: The invoked member is not supported before the type is created.
   at System.Reflection.Emit.TypeBuilder.GetField(String name, BindingFlags bindingAttr)
   at ProtoBuf.Grpc.Internal.ProxyEmitter.CreateFactory[TChannel,TService](Type baseType, BinderConfiguration binderConfig) in C:\Code\protobuf-net.Grpc\src\protobuf-net.Grpc\Internal\ProxyEmitter.cs:line 253
   at ProtoBuf.Grpc.Configuration.ClientFactory.DefaultProxyCache`3..cctor() in C:\Code\protobuf-net.Grpc\src\protobuf-net.Grpc\Configuration\ClientFactory.cs:line 68
   --- End of inner exception stack trace ---
```

Fix was found here: https://stackoverflow.com/questions/37488458/createtype-missing-from-typebuilder-how-to-port-this