### PR TITLE
Add alternative code-first POCO GRPC Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.idea/
 artifacts
 bin
 obj

--- a/protobuf-net.Grpc.sln
+++ b/protobuf-net.Grpc.sln
@@ -92,6 +92,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{6A3AC822-5
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfClient", "examples\perf\PerfClient\PerfClient.csproj", "{BCB98A08-8A05-41CA-B42F-9DBF3DB8D546}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "protobuf-net.Grpc.Test.Integration", "tests\protobuf-net.Grpc.Test.Integration\protobuf-net.Grpc.Test.Integration.csproj", "{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -237,6 +239,12 @@ Global
 		{BCB98A08-8A05-41CA-B42F-9DBF3DB8D546}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BCB98A08-8A05-41CA-B42F-9DBF3DB8D546}.VS|Any CPU.ActiveCfg = Debug|Any CPU
 		{BCB98A08-8A05-41CA-B42F-9DBF3DB8D546}.VS|Any CPU.Build.0 = Debug|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.VS|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32}.VS|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -275,6 +283,7 @@ Global
 		{419CBCB3-1FDC-4974-9F92-0E8BFEA3A7D7} = {6A3AC822-52E8-4AE2-8F71-385DF0D69891}
 		{6A3AC822-52E8-4AE2-8F71-385DF0D69891} = {F7FAC6AD-62B0-4B79-98AA-DBD99F84E4E9}
 		{BCB98A08-8A05-41CA-B42F-9DBF3DB8D546} = {6A3AC822-52E8-4AE2-8F71-385DF0D69891}
+		{7AF5B934-AEE9-4FD1-928D-AAE0F7098A32} = {0A84599D-2CE9-416E-888F-24652EEAB0B3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BA14B07C-CA29-430D-A600-F37A050636D3}

--- a/src/protobuf-net.Grpc/Configuration/IGrpcService.cs
+++ b/src/protobuf-net.Grpc/Configuration/IGrpcService.cs
@@ -1,0 +1,7 @@
+namespace ProtoBuf.Grpc.Configuration
+{
+    /// <summary>
+    /// Marker Interface to specify that all public methods on this class should be wired as GRPC Services 
+    /// </summary>
+    public interface IGrpcService {}
+}

--- a/src/protobuf-net.Grpc/Configuration/IGrpcService.cs
+++ b/src/protobuf-net.Grpc/Configuration/IGrpcService.cs
@@ -1,7 +1,9 @@
 namespace ProtoBuf.Grpc.Configuration
 {
     /// <summary>
-    /// Marker Interface to specify that all public methods on this class should be wired as GRPC Services 
+    /// When a type implements this interface, the type name (without any prefix or other qualification)
+    /// will be used as the name for resolving the gRPC service. All public methods defined by the type will be mapped as gRPC methods,
+    /// using their declared name. 
     /// </summary>
     public interface IGrpcService {}
 }

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -1,6 +1,8 @@
 ﻿using Grpc.Core;
 using ProtoBuf.Grpc.Internal;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -39,7 +41,11 @@ namespace ProtoBuf.Grpc.Configuration
             Type[] typesBuffer = Array.Empty<Type>();
             string? serviceName;
             if (binderConfiguration == null) binderConfiguration = BinderConfiguration.Default;
-            foreach (var serviceContract in ContractOperation.ExpandInterfaces(serviceType))
+            var serviceContracts = serviceType.GetInterfaces().Any(x => x == typeof(IGrpcService))
+                ? new HashSet<Type> { serviceType }
+                : ContractOperation.ExpandInterfaces(serviceType);
+
+            foreach (var serviceContract in serviceContracts)
             {
                 if (!binderConfiguration.Binder.IsServiceContract(serviceContract, out serviceName)) continue;
 

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -41,7 +41,7 @@ namespace ProtoBuf.Grpc.Configuration
             Type[] typesBuffer = Array.Empty<Type>();
             string? serviceName;
             if (binderConfiguration == null) binderConfiguration = BinderConfiguration.Default;
-            var serviceContracts = serviceType.GetInterfaces().Any(x => x == typeof(IGrpcService))
+            var serviceContracts = typeof(IGrpcService).IsAssignableFrom(serviceType)
                 ? new HashSet<Type> { serviceType }
                 : ContractOperation.ExpandInterfaces(serviceType);
 

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.ServiceModel;
 
@@ -49,6 +50,12 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         public virtual bool IsServiceContract(Type contractType, out string? name)
         {
+            if (contractType.GetInterfaces().Any(x => x == typeof(IGrpcService)))
+            {
+                name = contractType.Name;
+                return true;
+            }
+
             var sca = (ServiceContractAttribute?)Attribute.GetCustomAttribute(contractType, typeof(ServiceContractAttribute), inherit: true);
             if (sca == null)
             {
@@ -67,6 +74,12 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         public virtual bool IsOperationContract(MethodInfo method, out string? name)
         {
+            if (method.DeclaringType == typeof(object) || !method.IsPublic)
+            {
+                name = null;
+                return false;
+            }
+
             var oca = (OperationContractAttribute?)Attribute.GetCustomAttribute(method, typeof(OperationContractAttribute), inherit: true);
             string? opName = oca?.Name;
             if (string.IsNullOrWhiteSpace(opName))

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -50,7 +50,7 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         public virtual bool IsServiceContract(Type contractType, out string? name)
         {
-            if (contractType.GetInterfaces().Any(x => x == typeof(IGrpcService)))
+            if (typeof(IGrpcService).IsAssignableFrom(contractType))
             {
                 name = contractType.Name;
                 return true;

--- a/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
@@ -1,0 +1,135 @@
+using Grpc.Core;
+using ProtoBuf.Grpc.Server;
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Configuration;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test.Integration
+{
+    [DataContract]
+    public class Apply
+    {
+        public Apply() { }
+        public Apply(int x, int y) => (X, Y) = (x, y);
+
+        [DataMember(Order = 1)]
+        public int X { get; set; }
+
+        [DataMember(Order = 2)]
+        public int Y { get; set; }
+    }
+
+    [DataContract]
+    public class ApplyResponse
+    {
+        public ApplyResponse() { }
+        public ApplyResponse(int result) => Result = result;
+
+        [DataMember(Order = 1)]
+        public int Result { get; set; }
+    }
+    
+    public class ApplyServices : IGrpcService
+    {
+        public Task<ApplyResponse> Add(Apply request) => Task.FromResult(new ApplyResponse(request.X + request.Y));
+        public Task<ApplyResponse> Mul(Apply request) => Task.FromResult(new ApplyResponse(request.X * request.Y));
+        public Task<ApplyResponse> Sub(Apply request) => Task.FromResult(new ApplyResponse(request.X - request.Y));
+        public Task<ApplyResponse> Div(Apply request) => Task.FromResult(new ApplyResponse(request.X / request.Y));
+    }
+
+    public class GrpcServiceFixture : IAsyncDisposable
+    {
+        public const int Port = 10042;
+        private readonly Server _server;
+        
+        public GrpcServiceFixture()
+        {
+            _server = new Server
+            {
+                Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }
+            };
+            int opCount = _server.Services.AddCodeFirst(new ApplyServices());
+            _server.Start();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _server.ShutdownAsync();
+        }
+    }
+    
+    public class GrpcServiceTests : IClassFixture<GrpcServiceFixture>
+    {
+        private GrpcServiceFixture _fixture;
+        public GrpcServiceTests(GrpcServiceFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task CanCallAllApplyServices()
+        {
+            GrpcClientFactory.AllowUnencryptedHttp2 = true;
+            using var http = GrpcChannel.ForAddress($"http://localhost:{GrpcServiceFixture.Port}");
+
+            var request = new Apply { X = 6, Y = 3 };
+            var invoker = http.CreateCallInvoker();
+
+            var response = await invoker.Execute<Apply, ApplyResponse>(request, nameof(ApplyServices), nameof(ApplyServices.Add));
+            Assert.Equal(9, response.Result);
+            response = await invoker.Execute<Apply, ApplyResponse>(request, nameof(ApplyServices), nameof(ApplyServices.Mul));
+            Assert.Equal(18, response.Result);
+            response = await invoker.Execute<Apply, ApplyResponse>(request, nameof(ApplyServices), nameof(ApplyServices.Sub));
+            Assert.Equal(3, response.Result);
+            response = await invoker.Execute<Apply, ApplyResponse>(request, nameof(ApplyServices), nameof(ApplyServices.Div));
+            Assert.Equal(2, response.Result);
+        }
+    }
+    
+    public static class GrpcExtensions
+    {
+        public static Task<TResponse> Execute<TRequest, TResponse>(this Channel channel, TRequest request, string serviceName, string methodName,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+            => Execute<TRequest, TResponse>(new DefaultCallInvoker(channel), request, serviceName, methodName, options, host);
+        
+        public static async Task<TResponse> Execute<TRequest, TResponse>(this CallInvoker invoker, TRequest request, string serviceName, string methodName,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+        {
+            var method = new Method<TRequest, TResponse>(MethodType.Unary, serviceName, methodName,
+                CustomMarshaller<TRequest>.Instance, CustomMarshaller<TResponse>.Instance);
+            using (var auc = invoker.AsyncUnaryCall(method, host, options, request))
+            {
+                return await auc.ResponseAsync;
+            }
+        }
+        
+        class CustomMarshaller<T> : Marshaller<T>
+        {
+            public static readonly CustomMarshaller<T> Instance = new CustomMarshaller<T>();
+            private CustomMarshaller() : base(Serialize, Deserialize) { }
+
+            private static T Deserialize(byte[] payload)
+            {
+                using (var ms = new MemoryStream(payload))
+                {
+                    return ProtoBuf.Serializer.Deserialize<T>(ms);
+                }
+            }
+            private static byte[] Serialize(T payload)
+            {
+                using (var ms = new MemoryStream())
+                {
+                    ProtoBuf.Serializer.Serialize<T>(ms, payload);
+                    return ms.ToArray();
+                }
+            }
+        }
+    }    
+    
+}

--- a/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
+++ b/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <RootNamespace>protobuf_net.Grpc.Test.Integration</RootNamespace>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+        <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
+        <ProjectReference Include="..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Hi Mark,

Not sure how open you are to allow for an additional alternative code-first POCO alternative to specifying code-first Services, but the WCF-style interface isn't friendly to code-gen or being able to build genericized typed clients over specialized interfaces.

So I've included an (IMO) more natural alternative for defining GRPC Services by just having non-attributed POCO classes implementing the empty `IGrpcService` marker interface, e.g:

```csharp
public class ApplyServices : IGrpcService
{
    public Task<ApplyResponse> Add(Apply request) => 
        Task.FromResult(new ApplyResponse(request.X + request.Y));
    public Task<ApplyResponse> Mul(Apply request) => 
        Task.FromResult(new ApplyResponse(request.X * request.Y));
    public Task<ApplyResponse> Sub(Apply request) => 
        Task.FromResult(new ApplyResponse(request.X - request.Y));
    public Task<ApplyResponse> Div(Apply request) => 
        Task.FromResult(new ApplyResponse(request.X / request.Y));
}
```

Where the CodeFirst support will auto-wire all public methods in the class (except for Object methods) as GRPC Services. This was fairly non-disruptive to support (just a few LOC's in Binder classes).

I've included an integration test project to show how this can work without interfaces on the client using your Unary extension methods.

Let me know if you're open to this or would like me to make any further changes.
