### PR TITLE
Improve compatibility with legacy service contracts

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -80,8 +80,10 @@ namespace ProtoBuf.Grpc.Configuration
 
                     if (argsBuffer is null)
                     {
+                        var marshallerFactory = new ValueTypeWrapperMarshallerFactory(binderConfiguration!.MarshallerCache);
+                        var marshallerCache = new MarshallerCache(new[] { marshallerFactory });
                         argsBuffer = new object?[9];
-                        argsBuffer[6] = binderConfiguration!.MarshallerCache;
+                        argsBuffer[6] = marshallerCache;
                         argsBuffer[7] = service is null ? null : Expression.Constant(service, serviceType);
                     }
                     argsBuffer[0] = serviceName;

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -163,7 +163,7 @@ namespace ProtoBuf.Grpc.Configuration
                     else
                     {
                         // basic - direct call
-                        return (TDelegate)Delegate.CreateDelegate(typeof(TDelegate), _service, Method);
+                        return (TDelegate)Delegate.CreateDelegate(typeof(TDelegate), _service?.Value, Method);
                     }
                 }
                 else

--- a/src/protobuf-net.Grpc/Internal/ContractOperation.cs
+++ b/src/protobuf-net.Grpc/Internal/ContractOperation.cs
@@ -221,7 +221,7 @@ namespace ProtoBuf.Grpc.Internal
 
             if (!s_signaturePatterns.TryGetValue(signature, out var config)) return false;
 
-            static Type GetTupledType(Type[] types)
+            static Type GetTupledType(params Type[] types)
             {
                 return types.Length switch
                 {
@@ -238,8 +238,21 @@ namespace ProtoBuf.Grpc.Internal
                 };
             }
 
-            Type? arg0Type = dataArgsTypes.Length > 1 ? GetTupledType(dataArgsTypes) :
-                args.Length > 0 ? args[0].ParameterType : null;
+            Type? arg0Type = null;
+            if (dataArgsTypes.Length > 1)
+                arg0Type = GetTupledType(dataArgsTypes);
+            else if ((dataArgsTypes.Length == 1 && dataArgsTypes[0].IsValueType))
+                arg0Type = typeof(ValueTypeWrapper<>).MakeGenericType(dataArgsTypes[0]);
+            else if (args.Length > 0)
+                arg0Type = args[0].ParameterType;
+
+            Type retType = method.ReturnType;
+            if (signature.Ret == TypeCategory.Data && retType.IsValueType)
+                retType = typeof(ValueTypeWrapper<>).MakeGenericType(retType);
+            else if (signature.Ret == TypeCategory.TypedTask && retType.GetGenericArguments()[0].IsValueType)
+                retType = typeof(Task<>).MakeGenericType(typeof(ValueTypeWrapper<>).MakeGenericType(retType.GetGenericArguments()[0]));
+            else if (signature.Ret == TypeCategory.TypedValueTask && retType.GetGenericArguments()[0].IsValueType)
+                retType = typeof(ValueTask<>).MakeGenericType(typeof(ValueTypeWrapper<>).MakeGenericType(retType.GetGenericArguments()[0]));
 
             (Type type, TypeCategory category) GetTypeByIndex(int index)
             {
@@ -248,7 +261,7 @@ namespace ProtoBuf.Grpc.Internal
                     0 => (arg0Type!, signature.Arg0),
                     1 => (args[1].ParameterType, signature.Arg1),
                     2 => (args[2].ParameterType, signature.Arg2),
-                    RET => (method.ReturnType, signature.Ret),
+                    RET => (retType, signature.Ret),
                     VOID => (typeof(void), TypeCategory.Void),
                     _ => throw new IndexOutOfRangeException(nameof(index)),
                 };

--- a/src/protobuf-net.Grpc/Internal/ReflectionHelper.cs
+++ b/src/protobuf-net.Grpc/Internal/ReflectionHelper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace ProtoBuf.Grpc.Internal
+{
+    internal static class ReflectionHelper
+    {
+        public static MethodInfo GetContinueWithForTask(Type inputType, Type outputType)
+        {
+            var genericContinueWith = typeof(Task<>).MakeGenericType(inputType)
+                .GetMethods().Where(IsDesiredContinueWithMethod).Single();
+            return genericContinueWith.MakeGenericMethod(outputType);
+        }
+
+        public static bool IsDesiredContinueWithMethod(MethodInfo mi)
+        {
+            if (mi.Name != nameof(Task.ContinueWith))
+                return false;
+            var parameters = mi.GetParameters();
+            if (parameters.Length != 1)
+                return false;
+            var funcParamType = parameters[0].ParameterType;
+            if (!funcParamType.IsGenericType || funcParamType.GetGenericTypeDefinition() != typeof(Func<,>))
+                return false;
+            var taskArgument = funcParamType.GetGenericArguments()[0];
+            return taskArgument.IsGenericType && taskArgument.GetGenericTypeDefinition() == typeof(Task<>);
+        }
+
+    }
+}

--- a/src/protobuf-net.Grpc/Internal/ServerInvokerLookup.cs
+++ b/src/protobuf-net.Grpc/Internal/ServerInvokerLookup.cs
@@ -38,6 +38,27 @@ namespace ProtoBuf.Grpc.Internal
             return Expression.Call(typeof(Task), nameof(Task.FromResult), new Type[] { expression.Type }, expression);
         }
 
+        static Expression TupleDeconstruct(Expression instance, MethodInfo method, params Expression[] args)
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length == args.Length)
+                return Expression.Call(instance, method, args);
+
+            // assume args[0] is a Tuple with appropriate elements
+            var actualArgs = Enumerable.Range(0, parameters.Length - args.Length + 1)
+                .Select(i => GetNthItem(args[0], i))
+                .Concat(args.Skip(1))
+                .ToArray();
+
+            return Expression.Call(instance, method, actualArgs);
+
+            Expression GetNthItem(Expression tuple, int n) => n < 7
+                ? Expression.Property(tuple, tuple.Type.GetProperty($"Item{n + 1}") ??
+                                             throw new InvalidOperationException($"No property Item{n + 1} found on {tuple.Type.FullName}"))
+                : GetNthItem(Expression.Property(tuple, tuple.Type.GetProperty("Rest") ??
+                                                        throw new InvalidOperationException($"No property Rest found on {tuple.Type.FullName}")), n - 7);
+        }
+
         internal static readonly ConstructorInfo s_CallContext_FromServerContext = typeof(CallContext).GetConstructor(new[] { typeof(object), typeof(ServerCallContext) })!;
         internal static readonly PropertyInfo s_ServerContext_CancellationToken = typeof(ServerCallContext).GetProperty(nameof(ServerCallContext.CancellationToken))!;
 
@@ -72,28 +93,28 @@ namespace ProtoBuf.Grpc.Internal
 
                 // Unary: Task<TResponse> Foo(TService service, TRequest request, ServerCallContext serverCallContext);
                 // => service.{method}(request, [new CallContext(serverCallContext)])
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Task, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.ValueTask, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Sync, VoidKind.None), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
 
-                
+
                 // Unary: Task<TResponse> Foo(TService service, TRequest request, ServerCallContext serverCallContext);
                 // => service.{method}(request, [new CallContext(serverCallContext)]) return Empty.Instance;
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1])) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
-                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(Expression.Call(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.NoContext, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1])) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CallContext, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCallContext(args[0], args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Task, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.ValueTask, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
+                {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Sync, VoidKind.Response), (method, args) => ToTaskT(TupleDeconstruct(args[0], method, args[1], ToCancellationToken(args[2]))) },
 
                 // Unary: Task<TResponse> Foo(TService service, TRequest request, ServerCallContext serverCallContext);
                 // => service.{method}([new CallContext(serverCallContext)])
@@ -107,7 +128,7 @@ namespace ProtoBuf.Grpc.Internal
                 {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.ValueTask, VoidKind.Request), (method, args) => ToTaskT(Expression.Call(args[0], method, ToCancellationToken(args[2]))) },
                 {(MethodType.Unary, ContextKind.CancellationToken, ResultKind.Sync, VoidKind.Request), (method, args) => ToTaskT(Expression.Call(args[0], method, ToCancellationToken(args[2]))) },
 
-                
+
                 // Unary: Task<TResponse> Foo(TService service, TRequest request, ServerCallContext serverCallContext);
                 // => service.{method}([new CallContext(serverCallContext)]) return Empty.Instance;
                 {(MethodType.Unary, ContextKind.NoContext, ResultKind.Task, VoidKind.Both), (method, args) => ToTaskT(Expression.Call(args[0], method)) },
@@ -142,7 +163,7 @@ namespace ProtoBuf.Grpc.Internal
 
                 // Server Streaming: Task Foo(TService service, TRequest request, IServerStreamWriter<TResponse> stream, ServerCallContext serverCallContext);
                 // => service.{method}(request, [new CallContext(serverCallContext)]).WriteTo(stream, serverCallContext.CancellationToken)
-                {(MethodType.ServerStreaming, ContextKind.NoContext, ResultKind.AsyncEnumerable, VoidKind.None), (method, args) => WriteTo(Expression.Call(args[0], method, args[1]), args[2], args[3])},
+                {(MethodType.ServerStreaming, ContextKind.NoContext, ResultKind.AsyncEnumerable, VoidKind.None), (method, args) => WriteTo(TupleDeconstruct(args[0], method, args[1]), args[2], args[3])},
                 {(MethodType.ServerStreaming, ContextKind.CallContext, ResultKind.AsyncEnumerable, VoidKind.None), (method, args) => WriteTo(Expression.Call(args[0], method, args[1], ToCallContext(args[0], args[3])), args[2], args[3])},
                 {(MethodType.ServerStreaming, ContextKind.CancellationToken, ResultKind.AsyncEnumerable, VoidKind.None), (method, args) => WriteTo(Expression.Call(args[0], method, args[1], ToCancellationToken(args[3])), args[2], args[3])},
 

--- a/src/protobuf-net.Grpc/Internal/ValueTypeWrapper.cs
+++ b/src/protobuf-net.Grpc/Internal/ValueTypeWrapper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Grpc.Core;
+using ProtoBuf.Grpc.Configuration;
+
+namespace ProtoBuf.Grpc.Internal
+{
+    public class ValueTypeWrapper<T> where T : struct
+    {
+        public T Value;
+
+        public ValueTypeWrapper(T value)
+        {
+            Value = value;
+        }
+    }
+
+    internal class ValueTypeWrapperMarshallerFactory : MarshallerFactory
+    {
+        private MarshallerCache _cache;
+        static readonly MethodInfo s_getMarshaller = typeof(MarshallerCache).GetMethod(
+            nameof(MarshallerCache.GetMarshaller), BindingFlags.Instance | BindingFlags.NonPublic)!;
+        static readonly MethodInfo s_invokeDeserializer = typeof(ValueTypeWrapperMarshallerFactory).GetMethod(
+            nameof(InvokeDeserializer), BindingFlags.Instance | BindingFlags.NonPublic)!;
+        static readonly MethodInfo s_invokeSerializer = typeof(ValueTypeWrapperMarshallerFactory).GetMethod(
+            nameof(InvokeSerializer), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        internal ValueTypeWrapperMarshallerFactory(MarshallerCache cache)
+        {
+            _cache = cache;
+        }
+
+        protected internal override bool CanSerialize(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTypeWrapper<>))
+                type = type.GetGenericArguments()[0];
+
+            return _cache.CanSerializeType(type);
+        }
+
+        protected internal override Marshaller<T> CreateMarshaller<T>()
+        {
+            var type = typeof(T);
+            if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(ValueTypeWrapper<>))
+            {
+                return _cache.GetMarshaller<T>();
+            }
+
+            type = type.GetGenericArguments()[0];
+            var innerMarshaller = s_getMarshaller.MakeGenericMethod(type).Invoke(_cache, null);
+            var serializer = s_invokeSerializer.MakeGenericMethod(type);
+            var deserializer = s_invokeDeserializer.MakeGenericMethod(type);
+            return new Marshaller<T>((value, context) => serializer.Invoke(this, new object?[] { innerMarshaller, value, context }),
+                (context) => (T)deserializer.Invoke(this, new object?[] { innerMarshaller, context })!);
+        }
+
+        private void InvokeSerializer<T>(object marshaller, ValueTypeWrapper<T> value, global::Grpc.Core.SerializationContext context) where T : struct
+        {
+            ((Marshaller<T>)marshaller).ContextualSerializer(value.Value, context);
+        }
+
+        private ValueTypeWrapper<T> InvokeDeserializer<T>(object marshaller, DeserializationContext context) where T : struct
+        {
+            return new ValueTypeWrapper<T>(((Marshaller<T>)marshaller).ContextualDeserializer(context));
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test.Integration/StructClassCompatibilityTest.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/StructClassCompatibilityTest.cs
@@ -1,0 +1,145 @@
+#if !NETFRAMEWORK
+using System;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Server;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test.Integration
+{
+
+    [DataContract(Name = "MyDataContract")]
+    public class ClassContract
+    {
+        [DataMember(Order = 1)] public string S = string.Empty;
+        [DataMember(Order = 2)] public int N;
+    }
+
+    [DataContract(Name = "MyDataContract")]
+    public struct StructContract
+    {
+        [DataMember(Order = 1)] public string S;
+        [DataMember(Order = 2)] public int N;
+    }
+
+    [ServiceContract(Name = "MyServiceContract")]
+    public interface IMyServiceContract
+    {
+        ClassContract GetContract1(int n);
+        ValueTask<ClassContract> GetContract1Async(int n);
+        StructContract GetContract2();
+        Task<StructContract> GetContract2Async();
+        Task<bool> SaveContract1(ClassContract contract);
+        ValueTask<bool> SaveContract2(StructContract contract);
+    }
+
+    public class MyServiceContract : IMyServiceContract
+    {
+        public ClassContract GetContract1(int n)
+        {
+            return new ClassContract { S = "foo", N = n };
+        }
+
+        public ValueTask<ClassContract> GetContract1Async(int n)
+        {
+            return new ValueTask<ClassContract>(GetContract1(n));
+        }
+
+        public StructContract GetContract2()
+        {
+            return new StructContract { S = "foo", N = 42 };
+        }
+
+        public Task<StructContract> GetContract2Async()
+        {
+            return Task.FromResult(GetContract2());
+        }
+
+        public Task<bool> SaveContract1(ClassContract contract)
+        {
+            return Task.FromResult(true);
+        }
+        public ValueTask<bool> SaveContract2(StructContract contract)
+        {
+            return new ValueTask<bool>(false);
+        }
+    }
+
+    [ServiceContract(Name = "MyServiceContract")]
+    public interface IMyServiceContractClient
+    {
+        // swap actual types returned
+        StructContract GetContract1(int n);
+        ClassContract GetContract2();
+        Task<StructContract> GetContract1Async(int n);
+        ValueTask<ClassContract> GetContract2Async();
+        ValueTask<bool> SaveContract1(StructContract contract);
+        Task<bool> SaveContract2(ClassContract contract);
+    }
+
+    public class GrpcService2Fixture : IAsyncDisposable
+    {
+        public const int Port = 10043;
+        private readonly Server _server;
+
+        public GrpcService2Fixture()
+        {
+            _server = new Server
+            {
+                Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }
+            };
+            int opCount = _server.Services.AddCodeFirst(new MyServiceContract());
+            _server.Start();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _server.ShutdownAsync();
+        }
+    }
+    
+    public class StructClassCompatibilityTest : IClassFixture<GrpcService2Fixture>
+    {
+        private GrpcService2Fixture _fixture;
+        public StructClassCompatibilityTest(GrpcService2Fixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public async Task ValueTypeContractIsCompatibleWithClass()
+        {
+            GrpcClientFactory.AllowUnencryptedHttp2 = true;
+            using var http = GrpcChannel.ForAddress($"http://localhost:{GrpcService2Fixture.Port}");
+            IMyServiceContractClient proxy = http.CreateGrpcService<IMyServiceContractClient>();
+
+            var result1 = proxy.GetContract1(99);
+            Assert.IsType<StructContract>(result1);
+            Assert.Equal("foo", result1.S);
+            Assert.Equal(99, result1.N);
+
+            var result2 = proxy.GetContract2();
+            Assert.IsType<ClassContract>(result2);
+            Assert.Equal("foo", result2.S);
+            Assert.Equal(42, result2.N);
+
+            var result3 = await proxy.GetContract1Async(12);
+            Assert.IsType<StructContract>(result3);
+            Assert.Equal("foo", result3.S);
+            Assert.Equal(12, result3.N);
+
+            var result4 = await proxy.GetContract2Async();
+            Assert.IsType<ClassContract>(result4);
+            Assert.Equal("foo", result4.S);
+            Assert.Equal(42, result4.N);
+
+            bool result5 = await proxy.SaveContract1(new StructContract { S = "bar", N = 33 });
+            Assert.True(result5);
+
+            bool result6 = await proxy.SaveContract2(new ClassContract { S = "bar", N = 33 });
+            Assert.False(result6);
+        }
+    }
+}
+#endif

--- a/tests/protobuf-net.Grpc.Test.IntegrationUpLevel/protobuf-net.Grpc.Test.IntegrationUpLevel.csproj
+++ b/tests/protobuf-net.Grpc.Test.IntegrationUpLevel/protobuf-net.Grpc.Test.IntegrationUpLevel.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/protobuf-net.Grpc.Test/AllOptionsService.cs
+++ b/tests/protobuf-net.Grpc.Test/AllOptionsService.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using ProtoBuf.Grpc;
+
+namespace protobuf_net.Grpc.Test
+{
+    public class AllOptionsService : IAllOptions
+    {
+        // shortcoming of compiler : simple implementation of IAsyncEnumerable<> uses the async keyword,
+        // but then we get a CS1998 warning if nothing is awaited
+#pragma warning disable 1998
+
+        // Client call context meaningless on Server side
+        public HelloReply Client_BlockingUnary(HelloRequest request, CallOptions options) => throw new NotSupportedException();
+
+        public AsyncUnaryCall<HelloReply> Client_AsyncUnary(HelloRequest request, CallOptions options) => throw new NotSupportedException();
+
+        public AsyncClientStreamingCall<HelloRequest, HelloReply> Client_ClientStreaming(CallOptions options) => throw new NotSupportedException();
+
+        public AsyncDuplexStreamingCall<HelloRequest, HelloReply> Client_Duplex(CallOptions options) => throw new NotSupportedException();
+
+        public AsyncServerStreamingCall<HelloReply> Client_ServerStreaming(HelloRequest request, CallOptions options) => throw new NotSupportedException();
+
+        public Task<HelloReply> Server_Unary(HelloRequest request, ServerCallContext context) => Task.FromResult(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public async Task<HelloReply> Server_ClientStreaming(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
+        {
+            bool hasNext = await requestStream.MoveNext();
+            return new HelloReply { Message = $"Hello {(hasNext ? requestStream.Current.Name : "Anonymous Coward")}" };
+        }
+
+        public async Task Server_ServerStreaming(HelloRequest request, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            await responseStream.WriteAsync(new HelloReply { Message = $"Hello {request.Name}" });
+        }
+
+        public async Task Server_Duplex(IAsyncStreamReader<HelloRequest> requestStream, IServerStreamWriter<HelloReply> responseStream, ServerCallContext context)
+        {
+            while (await requestStream.MoveNext())
+                await responseStream.WriteAsync(new HelloReply { Message = $"Hello {requestStream.Current.Name}" });
+        }
+
+        public HelloReply Shared_BlockingUnary_NoContext(HelloRequest request) => new HelloReply { Message = $"Hello {request.Name}" };
+
+        public HelloReply Shared_BlockingUnary_Context(HelloRequest request, CallContext context) => new HelloReply { Message = $"Hello {request.Name}" };
+
+        public HelloReply Shared_BlockingUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken) => new HelloReply { Message = $"Hello {request.Name}" };
+
+        public void Shared_BlockingUnary_NoContext_VoidVoid() { }
+
+        public void Shared_BlockingUnary_Context_VoidVoid(CallContext context) { }
+
+        public void Shared_BlockingUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken) { }
+
+        public HelloReply Shared_BlockingUnary_NoContext_VoidVal() => new HelloReply { Message = "Hello Anonymous Coward" };
+
+        public HelloReply Shared_BlockingUnary_Context_VoidVal(CallContext context) => new HelloReply { Message = "Hello Anonymous Coward" };
+
+        public HelloReply Shared_BlockingUnary_CancellationToken_VoidVal(CancellationToken cancellationToken) => new HelloReply { Message = "Hello Anonymous Coward" };
+
+        public void Shared_BlockingUnary_NoContext_ValVoid(HelloRequest request) { }
+
+        public void Shared_BlockingUnary_Context_ValVoid(HelloRequest request, CallContext context) { }
+
+        public void Shared_BlockingUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken) { }
+
+        public Task<HelloReply> Shared_TaskUnary_NoContext(HelloRequest request) => Task.FromResult(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public Task<HelloReply> Shared_TaskUnary_Context(HelloRequest request, CallContext context) => Task.FromResult(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public Task<HelloReply> Shared_TaskUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken) => Task.FromResult(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public Task Shared_TaskUnary_NoContext_VoidVoid() => Task.CompletedTask;
+
+        public Task Shared_TaskUnary_Context_VoidVoid(CallContext context) => Task.CompletedTask;
+
+        public Task Shared_TaskUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<HelloReply> Shared_TaskUnary_NoContext_VoidVal() => Task.FromResult(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public Task<HelloReply> Shared_TaskUnary_Context_VoidVal(CallContext context) => Task.FromResult(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public Task<HelloReply> Shared_TaskUnary_CancellationToken_VoidVal(CancellationToken cancellationToken) => Task.FromResult(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public Task Shared_TaskUnary_NoContext_ValVoid(HelloRequest request) => Task.CompletedTask;
+
+        public Task Shared_TaskUnary_Context_ValVoid(HelloRequest request, CallContext context) => Task.CompletedTask;
+
+        public Task Shared_TaskUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_NoContext(HelloRequest request) => new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_Context(HelloRequest request, CallContext context) => new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken) => new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {request.Name}" });
+
+        public ValueTask Shared_ValueTaskUnary_NoContext_VoidVoid() => new ValueTask();
+
+        public ValueTask Shared_ValueTaskUnary_Context_VoidVoid(CallContext context) => new ValueTask();
+
+        public ValueTask Shared_ValueTaskUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken) => new ValueTask();
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_NoContext_VoidVal() => new ValueTask<HelloReply>(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_Context_VoidVal(CallContext context) => new ValueTask<HelloReply>(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public ValueTask<HelloReply> Shared_ValueTaskUnary_CancellationToken_VoidVal(CancellationToken cancellationToken) => new ValueTask<HelloReply>(new HelloReply { Message = "Hello Anonymous Coward" });
+
+        public ValueTask Shared_ValueTaskUnary_NoContext_ValVoid(HelloRequest request) => new ValueTask();
+
+        public ValueTask Shared_ValueTaskUnary_Context_ValVoid(HelloRequest request, CallContext context) => new ValueTask();
+
+        public ValueTask Shared_ValueTaskUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken) => new ValueTask();
+
+        public async Task<HelloReply> Shared_TaskClientStreaming_NoContext(IAsyncEnumerable<HelloRequest> requestStream)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async Task<HelloReply> Shared_TaskClientStreaming_Context(IAsyncEnumerable<HelloRequest> requestStream, CallContext context)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async Task<HelloReply> Shared_TaskClientStreaming_CancellationToken(IAsyncEnumerable<HelloRequest> requestStream, CancellationToken cancellationToken)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async Task Shared_TaskClientStreaming_NoContext_ValVoid(IAsyncEnumerable<HelloRequest> requestStream)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async Task Shared_TaskClientStreaming_Context_ValVoid(IAsyncEnumerable<HelloRequest> requestStream, CallContext context)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async Task Shared_TaskClientStreaming_CancellationToken_ValVoid(IAsyncEnumerable<HelloRequest> requestStream, CancellationToken cancellationToken)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async ValueTask<HelloReply> Shared_ValueTaskClientStreaming_NoContext(IAsyncEnumerable<HelloRequest> requestStream)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async ValueTask<HelloReply> Shared_ValueTaskClientStreaming_Context(IAsyncEnumerable<HelloRequest> requestStream, CallContext context)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async ValueTask<HelloReply> Shared_ValueTaskClientStreaming_CancellationToken(IAsyncEnumerable<HelloRequest> requestStream, CancellationToken cancellationToken)
+        {
+            HelloRequest? request = null;
+            await foreach (var req in requestStream)
+                request = req;
+            return new HelloReply { Message = $"Hello {request?.Name ?? "Anonymous Coward"}" };
+        }
+
+        public async ValueTask Shared_ValueTaskClientStreaming_NoContext_ValVoid(IAsyncEnumerable<HelloRequest> requestStream)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async ValueTask Shared_ValueTaskClientStreaming_Context_ValVoid(IAsyncEnumerable<HelloRequest> requestStream, CallContext context)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async ValueTask Shared_ValueTaskClientStreaming_CancellationToken_ValVoid(IAsyncEnumerable<HelloRequest> requestStream, CancellationToken cancellationToken)
+        {
+            await foreach (var _ in requestStream)
+            {
+            }
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_NoContext(HelloRequest request)
+        {
+            yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_Context(HelloRequest request, CallContext context)
+        {
+            yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_CancellationToken(HelloRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_NoContext_VoidVal()
+        {
+            yield return new HelloReply { Message = $"Hello Anonymous Coward" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_Context_VoidVal(CallContext context)
+        {
+            yield return new HelloReply { Message = $"Hello Anonymous Coward" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_ServerStreaming_CancellationToken_VoidVal([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new HelloReply { Message = $"Hello Anonymous Coward" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_Duplex_NoContext(IAsyncEnumerable<HelloRequest> requestStream)
+        {
+            await foreach (var request in requestStream)
+                yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_Duplex_Context(IAsyncEnumerable<HelloRequest> requestStream, CallContext context)
+        {
+            await foreach (var request in requestStream)
+                yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+
+        public async IAsyncEnumerable<HelloReply> Shared_Duplex_CancellationToken(IAsyncEnumerable<HelloRequest> requestStream, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (var request in requestStream)
+                yield return new HelloReply { Message = $"Hello {request.Name}" };
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/CodeGenerationTest.cs
+++ b/tests/protobuf-net.Grpc.Test/CodeGenerationTest.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using ProtoBuf.Grpc.Configuration;
+using ProtoBuf.Grpc.Internal;
+using ProtoBuf.Grpc;
+using Xunit;
+
+// Type or member is obsolete : internal types are not really obsolete, just used internally, which is precisely what we want to test
+#pragma warning disable CS0618
+
+namespace protobuf_net.Grpc.Test
+{
+    public class CodeGenerationTest
+    {
+        public class Binder : ServerBinder
+        {
+            protected override bool TryBind<TService, TRequest, TResponse>(ServiceBindContext bindContext, Method<TRequest, TResponse> method, MethodStub<TService> stub)
+            {
+                var builder = (ServerServiceDefinition.Builder)bindContext.State;
+                switch (method.Type)
+                {
+                    case MethodType.Unary:
+                        builder.AddMethod(method, stub.CreateDelegate<UnaryServerMethod<TRequest, TResponse>>());
+                        break;
+                    case MethodType.ClientStreaming:
+                        builder.AddMethod(method, stub.CreateDelegate<ClientStreamingServerMethod<TRequest, TResponse>>());
+                        break;
+                    case MethodType.ServerStreaming:
+                        builder.AddMethod(method, stub.CreateDelegate<ServerStreamingServerMethod<TRequest, TResponse>>());
+                        break;
+                    case MethodType.DuplexStreaming:
+                        builder.AddMethod(method, stub.CreateDelegate<DuplexStreamingServerMethod<TRequest, TResponse>>());
+                        break;
+                    default:
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        public static IEnumerable<object[]> IAllOptionsMethods => typeof(IAllOptions).GetMethods().Select(m => new object[] { m });
+
+        [Theory]
+        [MemberData(nameof(IAllOptionsMethods))]
+        public async void GenerateIAllOptionsProxy(MethodInfo method)
+        {
+            if (!method.Name.StartsWith("Shared"))
+                return;
+
+            Assert.True(method.GetParameters().All(p =>
+                p.ParameterType == typeof(HelloRequest) ||
+                p.ParameterType == typeof(CallContext) ||
+                p.ParameterType == typeof(CancellationToken) ||
+                p.ParameterType == typeof(IAsyncEnumerable<HelloRequest>)));
+
+            var builder = ServerServiceDefinition.CreateBuilder();
+            new Binder().Bind(builder, null, new AllOptionsService());
+            var serviceDefinition = builder.Build();
+            // I don't understand why this is internal...
+            var bindService = typeof(ServerServiceDefinition).GetMethod("BindService", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(bindService);
+
+            var serviceBinder = new MockServiceBinder();
+            // Assert.NotNull not (yet ?) identified as returning only if arg is not null...
+            bindService!.Invoke(serviceDefinition, new object[] { serviceBinder });
+            var callInvoker = new MockCallInvoker(serviceBinder);
+            var factory = ProxyEmitter.CreateFactory<IAllOptions>(BinderConfiguration.Default);
+
+            IAllOptions proxy = factory(callInvoker);
+
+            var parameters = method.GetParameters().Select(p =>
+                    p.ParameterType == typeof(HelloRequest) ? (object)new HelloRequest { Name = "John" } :
+                    p.ParameterType == typeof(IAsyncEnumerable<HelloRequest>) ? (object)SomeRequests() :
+                    p.ParameterType == typeof(CallContext) ? (object)new CallContext() :
+                    p.ParameterType == typeof(CancellationToken) ? (object)CancellationToken.None : null)
+                .ToArray();
+
+            var result = method.Invoke(proxy, parameters);
+
+            switch (result)
+            {
+                case HelloReply reply:
+                    Assert.StartsWith("Hello", reply.Message);
+                    break;
+                case Task<HelloReply> replyTask:
+                    Assert.StartsWith("Hello", (await replyTask).Message);
+                    break;
+                case ValueTask<HelloReply> replyTask:
+                    Assert.StartsWith("Hello", (await replyTask).Message);
+                    break;
+                case IAsyncEnumerable<HelloReply> replyStream:
+                    var enumerator = replyStream.GetAsyncEnumerator();
+                    await enumerator.MoveNextAsync();
+                    Assert.StartsWith("Hello", enumerator.Current.Message);
+                    break;
+                case Task task:
+                    await task;
+                    break;
+                case ValueTask task:
+                    await task;
+                    break;
+                case null:  // void-returning methods get a null result when called via Invoke
+                    break;
+                default:
+                    Assert.True(false, $"Unexpected result type {result}");
+                    break;
+            }
+
+#pragma warning disable 1998
+            async IAsyncEnumerable<HelloRequest> SomeRequests()
+            {
+                for (int i = 0; i < 3; i++)
+                    yield return new HelloRequest { Name = $"John {i + 1}"};
+            }
+#pragma warning restore 1998
+        }
+        public static IEnumerable<object[]> ILegacyServiceMethods => typeof(ILegacyService).GetMethods().Select(m => new object[] { m });
+
+        [Theory]
+        [MemberData(nameof(ILegacyServiceMethods))]
+        public async Task GenerateILegacyServiceProxy(MethodInfo method)
+        {
+            Assert.True(method.GetParameters().All(p =>
+                p.ParameterType == typeof(string) ||
+                p.ParameterType == typeof(long) ||
+                p.ParameterType == typeof(HelloRequest) ||
+                p.ParameterType == typeof(CancellationToken)));
+
+            var builder = ServerServiceDefinition.CreateBuilder();
+            new Binder().Bind(builder, null, new LegacyService());
+            var serviceDefinition = builder.Build();
+            // I don't understand why this is internal...
+            var bindService = typeof(ServerServiceDefinition).GetMethod("BindService", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(bindService);
+
+            var serviceBinder = new MockServiceBinder();
+            // Assert.NotNull not (yet ?) identified as returning only if arg is not null...
+            bindService!.Invoke(serviceDefinition, new object[] { serviceBinder });
+            var callInvoker = new MockCallInvoker(serviceBinder);
+            var factory = ProxyEmitter.CreateFactory<ILegacyService>(BinderConfiguration.Default);
+
+            ILegacyService proxy = factory(callInvoker);
+
+            var parameters = method.GetParameters().Select(p =>
+                    p.ParameterType == typeof(HelloRequest) ? (object)new HelloRequest { Name = "John" } :
+                    p.ParameterType == typeof(string) ? (object)"John" :
+                    p.ParameterType == typeof(long) ? (object)42 :
+                    p.ParameterType == typeof(CancellationToken) ? (object)CancellationToken.None : null)
+                .ToArray();
+
+            var result = method.Invoke(proxy, parameters);
+
+            const string expectedMessage = "Hello John, aged 42";
+            switch (result)
+            {
+                case HelloReply reply:
+                    Assert.Equal(expectedMessage, reply.Message);
+                    break;
+                case Task<HelloReply> replyTask:
+                    Assert.Equal(expectedMessage, (await replyTask).Message);
+                    break;
+                case ValueTask<HelloReply> replyTask:
+                    Assert.Equal(expectedMessage, (await replyTask).Message);
+                    break;
+                case Task task:
+                    // a Task<something_unexpected> derives from Task, so would match here
+                    Assert.Equal(typeof(Task), method.ReturnType);
+                    await task;
+                    break;
+                case ValueTask task:
+                    // Note that ValueTask<T> does *not* derive from ValueTask
+                    await task;
+                    break;
+                case null:  // void-returning methods get a null result when called via Invoke
+                    break;
+                default:
+                    Assert.True(false, $"Unexpected result type {result}");
+                    break;
+            }
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/CodeGenerationTest.cs
+++ b/tests/protobuf-net.Grpc.Test/CodeGenerationTest.cs
@@ -128,6 +128,8 @@ namespace protobuf_net.Grpc.Test
             Assert.True(method.GetParameters().All(p =>
                 p.ParameterType == typeof(string) ||
                 p.ParameterType == typeof(long) ||
+                p.ParameterType == typeof(DateTime) ||
+                p.ParameterType == typeof(IList<DateTime>) ||
                 p.ParameterType == typeof(HelloRequest) ||
                 p.ParameterType == typeof(CancellationToken)));
 
@@ -150,12 +152,15 @@ namespace protobuf_net.Grpc.Test
                     p.ParameterType == typeof(HelloRequest) ? (object)new HelloRequest { Name = "John" } :
                     p.ParameterType == typeof(string) ? (object)"John" :
                     p.ParameterType == typeof(long) ? (object)42 :
+                    p.ParameterType == typeof(DateTime) ? (object)DateTime.Now :
+                    p.ParameterType == typeof(IList<DateTime>) ? (object)new[] { DateTime.Now } :
                     p.ParameterType == typeof(CancellationToken) ? (object)CancellationToken.None : null)
                 .ToArray();
 
             var result = method.Invoke(proxy, parameters);
 
             const string expectedMessage = "Hello John, aged 42";
+            const long expectedLong = 42;
             switch (result)
             {
                 case HelloReply reply:
@@ -166,6 +171,24 @@ namespace protobuf_net.Grpc.Test
                     break;
                 case ValueTask<HelloReply> replyTask:
                     Assert.Equal(expectedMessage, (await replyTask).Message);
+                    break;
+                case long reply:
+                    Assert.Equal(expectedLong, reply);
+                    break;
+                case Task<long> replyTask:
+                    Assert.Equal(expectedLong, await replyTask);
+                    break;
+                case ValueTask<long> replyTask:
+                    Assert.Equal(expectedLong, await replyTask);
+                    break;
+                case IList<long> reply:
+                    Assert.Equal(new[] { expectedLong }, reply);
+                    break;
+                case Task<IList<long>> replyTask:
+                    Assert.Equal(new[] { expectedLong }, await replyTask);
+                    break;
+                case ValueTask<IList<long>> replyTask:
+                    Assert.Equal(new[] { expectedLong }, await replyTask);
                     break;
                 case Task task:
                     // a Task<something_unexpected> derives from Task, so would match here

--- a/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
+++ b/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
@@ -206,6 +206,10 @@ namespace protobuf_net.Grpc.Test
             typeof(Tuple<string, long, HelloRequest, string, long, HelloRequest, string, Tuple<long, HelloRequest>>),
             typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.None)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_BlockingUnary_ValVoid), typeof(Tuple<string, long>), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Response)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_BlockingUnary_ValueTypeVoid), typeof(ValueTypeWrapper<long>), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Response)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_BlockingUnary_ValueTypeValueType), typeof(ValueTypeWrapper<DateTime>), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_BlockingUnary_IListValueTypeIListValueType), typeof(IList<DateTime>), typeof(IList<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_BlockingUnary_VoidValueType), typeof(Empty), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Request)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary), typeof(Tuple<string, long>), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.None)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_ValVoid), typeof(Tuple<string, long>), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Response)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary), typeof(Tuple<string, long>), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
@@ -214,6 +218,14 @@ namespace protobuf_net.Grpc.Test
         [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_CancellationToken_ValVoid), typeof(Tuple<string, long>), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.Response)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_CancellationToken), typeof(Tuple<string, long>), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.None)]
         [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_CancellationToken_ValVoid), typeof(Tuple<string, long>), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_ValueTypeVoid), typeof(ValueTypeWrapper<long>), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Response)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_ValueTypeValueType), typeof(ValueTypeWrapper<DateTime>), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_IListValueTypeIListValueType), typeof(IList<DateTime>), typeof(IList<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_TaskUnary_VoidValueType), typeof(Empty), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Request)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_ValueTypeVoid), typeof(ValueTypeWrapper<long>), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_ValueTypeValueType), typeof(ValueTypeWrapper<DateTime>), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_IListValueTypeIListValueType), typeof(IList<DateTime>), typeof(IList<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
+        [InlineData(nameof(ILegacyService.Shared_Legacy_ValueTaskUnary_VoidValueType), typeof(Empty), typeof(ValueTypeWrapper<long>), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Request)]
         public void CheckLegacyMethodIdentification(string name, Type from, Type to, MethodType methodType, int context, int result, int @void)
         {
             CheckMethodIdentification(name, from, to, methodType, context, result, @void);

--- a/tests/protobuf-net.Grpc.Test/IAllOptions.cs
+++ b/tests/protobuf-net.Grpc.Test/IAllOptions.cs
@@ -23,7 +23,7 @@ namespace protobuf_net.Grpc.Test
 
 
     [ServiceContract]
-    interface IAllOptions
+    public interface IAllOptions
     {
         // google client patterns
         HelloReply Client_BlockingUnary(HelloRequest request, CallOptions options);

--- a/tests/protobuf-net.Grpc.Test/ILegacyService.cs
+++ b/tests/protobuf-net.Grpc.Test/ILegacyService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ServiceModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,12 @@ namespace protobuf_net.Grpc.Test
             string arg4, long arg5, HelloRequest arg6,string arg7, long arg8, HelloRequest arg9);
         void Shared_Legacy_BlockingUnary_ValVoid(string arg1, long arg2);
 
+        // blocking, ValueType
+        void Shared_Legacy_BlockingUnary_ValueTypeVoid(long arg);
+        long Shared_Legacy_BlockingUnary_ValueTypeValueType(DateTime arg);
+        IList<long> Shared_Legacy_BlockingUnary_IListValueTypeIListValueType(IList<DateTime> arg);
+        long Shared_Legacy_BlockingUnary_VoidValueType();
+
         // async, multiple arguments
         Task<HelloReply> Shared_Legacy_TaskUnary(string arg1, long arg2);
         Task Shared_Legacy_TaskUnary_ValVoid(string arg1, long arg2);
@@ -28,5 +35,15 @@ namespace protobuf_net.Grpc.Test
         Task Shared_Legacy_TaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken);
         ValueTask<HelloReply> Shared_Legacy_ValueTaskUnary_CancellationToken(string arg1, long arg2, CancellationToken cancellationToken);
         ValueTask Shared_Legacy_ValueTaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken);
+
+        // async, ValueType
+        Task Shared_Legacy_TaskUnary_ValueTypeVoid(long arg);
+        Task<long> Shared_Legacy_TaskUnary_ValueTypeValueType(DateTime arg);
+        Task<IList<long>> Shared_Legacy_TaskUnary_IListValueTypeIListValueType(IList<DateTime> arg);
+        Task<long> Shared_Legacy_TaskUnary_VoidValueType();
+        ValueTask Shared_Legacy_ValueTaskUnary_ValueTypeVoid(long arg);
+        ValueTask<long> Shared_Legacy_ValueTaskUnary_ValueTypeValueType(DateTime arg);
+        ValueTask<IList<long>> Shared_Legacy_ValueTaskUnary_IListValueTypeIListValueType(IList<DateTime> arg);
+        ValueTask<long> Shared_Legacy_ValueTaskUnary_VoidValueType();
     }
 }

--- a/tests/protobuf-net.Grpc.Test/ILegacyService.cs
+++ b/tests/protobuf-net.Grpc.Test/ILegacyService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ServiceModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace protobuf_net.Grpc.Test
+{
+    /// <summary>
+    /// Legacy ServiceContract, not directly in the gRPC Request/Reply model
+    /// </summary>
+    [ServiceContract]
+    interface ILegacyService
+    {
+        // blocking, multiple arguments
+        HelloReply Shared_Legacy_BlockingUnary(string arg1, long arg2);
+        HelloReply Shared_Legacy_BlockingUnary_ManyArgs(string arg1, long arg2, HelloRequest arg3,
+            string arg4, long arg5, HelloRequest arg6,string arg7, long arg8, HelloRequest arg9);
+        void Shared_Legacy_BlockingUnary_ValVoid(string arg1, long arg2);
+
+        // async, multiple arguments
+        Task<HelloReply> Shared_Legacy_TaskUnary(string arg1, long arg2);
+        Task Shared_Legacy_TaskUnary_ValVoid(string arg1, long arg2);
+        ValueTask<HelloReply> Shared_Legacy_ValueTaskUnary(string arg1, long arg2);
+        ValueTask Shared_Legacy_ValueTaskUnary_ValVoid(string arg1, long arg2);
+
+        // async, multiple arguments and a CancellationToken
+        Task<HelloReply> Shared_Legacy_TaskUnary_CancellationToken(string arg1, long arg2, CancellationToken cancellationToken);
+        Task Shared_Legacy_TaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken);
+        ValueTask<HelloReply> Shared_Legacy_ValueTaskUnary_CancellationToken(string arg1, long arg2, CancellationToken cancellationToken);
+        ValueTask Shared_Legacy_ValueTaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken);
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/ILegacyService.cs
+++ b/tests/protobuf-net.Grpc.Test/ILegacyService.cs
@@ -9,7 +9,7 @@ namespace protobuf_net.Grpc.Test
     /// Legacy ServiceContract, not directly in the gRPC Request/Reply model
     /// </summary>
     [ServiceContract]
-    interface ILegacyService
+    public interface ILegacyService
     {
         // blocking, multiple arguments
         HelloReply Shared_Legacy_BlockingUnary(string arg1, long arg2);

--- a/tests/protobuf-net.Grpc.Test/LegacyService.cs
+++ b/tests/protobuf-net.Grpc.Test/LegacyService.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace protobuf_net.Grpc.Test
@@ -11,6 +14,14 @@ namespace protobuf_net.Grpc.Test
         public HelloReply Shared_Legacy_BlockingUnary_ManyArgs(string arg1, long arg2, HelloRequest arg3, string arg4, long arg5,
             HelloRequest arg6, string arg7, long arg8, HelloRequest arg9) =>
             new HelloReply { Message = $"Hello {arg1}, aged {arg2}" };
+
+        public long Shared_Legacy_BlockingUnary_VoidValueType() => 42;
+
+        public long Shared_Legacy_BlockingUnary_ValueTypeValueType(DateTime arg) => 42;
+
+        public IList<long> Shared_Legacy_BlockingUnary_IListValueTypeIListValueType(IList<DateTime> arg) => arg.Select(_ => 42L).ToList();
+
+        public void Shared_Legacy_BlockingUnary_ValueTypeVoid(long arg) { }
 
         public void Shared_Legacy_BlockingUnary_ValVoid(string arg1, long arg2) { }
 
@@ -33,5 +44,23 @@ namespace protobuf_net.Grpc.Test
             new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {arg1}, aged {arg2}" });
 
         public ValueTask Shared_Legacy_ValueTaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken) => new ValueTask();
+
+        public Task Shared_Legacy_TaskUnary_ValueTypeVoid(long arg) => Task.CompletedTask;
+
+        public Task<long> Shared_Legacy_TaskUnary_ValueTypeValueType(DateTime arg) => Task.FromResult(42L);
+
+        public Task<IList<long>> Shared_Legacy_TaskUnary_IListValueTypeIListValueType(IList<DateTime> arg) =>
+            Task.FromResult((IList<long>)arg.Select(_ => 42L).ToList());
+
+        public Task<long> Shared_Legacy_TaskUnary_VoidValueType() => Task.FromResult(42L);
+
+        public ValueTask Shared_Legacy_ValueTaskUnary_ValueTypeVoid(long arg) => new ValueTask();
+
+        public ValueTask<long> Shared_Legacy_ValueTaskUnary_ValueTypeValueType(DateTime arg) => new ValueTask<long>(42);
+
+        public ValueTask<IList<long>> Shared_Legacy_ValueTaskUnary_IListValueTypeIListValueType(IList<DateTime> arg) =>
+            new ValueTask<IList<long>>((IList<long>) arg.Select(_ => 42L).ToList());
+
+        public ValueTask<long> Shared_Legacy_ValueTaskUnary_VoidValueType() => new ValueTask<long>(42);
     }
 }

--- a/tests/protobuf-net.Grpc.Test/LegacyService.cs
+++ b/tests/protobuf-net.Grpc.Test/LegacyService.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace protobuf_net.Grpc.Test
+{
+    public class LegacyService : ILegacyService
+    {
+        public HelloReply Shared_Legacy_BlockingUnary(string arg1, long arg2) =>
+            new HelloReply { Message = $"Hello {arg1}, aged {arg2}" };
+
+        public HelloReply Shared_Legacy_BlockingUnary_ManyArgs(string arg1, long arg2, HelloRequest arg3, string arg4, long arg5,
+            HelloRequest arg6, string arg7, long arg8, HelloRequest arg9) =>
+            new HelloReply { Message = $"Hello {arg1}, aged {arg2}" };
+
+        public void Shared_Legacy_BlockingUnary_ValVoid(string arg1, long arg2) { }
+
+        public Task<HelloReply> Shared_Legacy_TaskUnary(string arg1, long arg2) =>
+            Task.FromResult(new HelloReply { Message = $"Hello {arg1}, aged {arg2}" });
+
+        public Task Shared_Legacy_TaskUnary_ValVoid(string arg1, long arg2) => Task.CompletedTask;
+
+        public ValueTask<HelloReply> Shared_Legacy_ValueTaskUnary(string arg1, long arg2) =>
+            new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {arg1}, aged {arg2}" });
+
+        public ValueTask Shared_Legacy_ValueTaskUnary_ValVoid(string arg1, long arg2) => new ValueTask();
+
+        public Task<HelloReply> Shared_Legacy_TaskUnary_CancellationToken(string arg1, long arg2, CancellationToken cancellationToken) =>
+            Task.FromResult(new HelloReply { Message = $"Hello {arg1}, aged {arg2}" });
+
+        public Task Shared_Legacy_TaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public ValueTask<HelloReply> Shared_Legacy_ValueTaskUnary_CancellationToken(string arg1, long arg2, CancellationToken cancellationToken) =>
+            new ValueTask<HelloReply>(new HelloReply { Message = $"Hello {arg1}, aged {arg2}" });
+
+        public ValueTask Shared_Legacy_ValueTaskUnary_CancellationToken_ValVoid(string arg1, long arg2, CancellationToken cancellationToken) => new ValueTask();
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/MockCallInvoker.cs
+++ b/tests/protobuf-net.Grpc.Test/MockCallInvoker.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace protobuf_net.Grpc.Test
+{
+    public class MockCallInvoker : CallInvoker
+    {
+        private class MockServerCallContext : ServerCallContext
+        {
+            protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders)
+            {
+                return Task.CompletedTask;
+            }
+
+            protected override ContextPropagationToken? CreatePropagationTokenCore(ContextPropagationOptions options)
+            {
+                return null;
+            }
+
+            protected override string? MethodCore { get; }
+            protected override string? HostCore { get; }
+            protected override string? PeerCore { get; }
+            protected override DateTime DeadlineCore { get; }
+            protected override Metadata? RequestHeadersCore { get; }
+            protected override CancellationToken CancellationTokenCore { get; }
+            protected override Metadata? ResponseTrailersCore { get; }
+            protected override Status StatusCore { get; set; }
+            protected override WriteOptions? WriteOptionsCore { get; set; }
+            protected override AuthContext? AuthContextCore { get; }
+        }
+
+        private class PassThroughStream<T> : IServerStreamWriter<T>, IAsyncStreamReader<T>, IClientStreamWriter<T>
+        {
+            private readonly Channel<T> _channel = System.Threading.Channels.Channel.CreateUnbounded<T>();
+
+            public Task WriteAsync(T message)
+            {
+                return _channel.Writer.WriteAsync(message).AsTask();
+            }
+
+            public WriteOptions? WriteOptions { get; set; }
+
+            public T Current { get; private set; } = default!;
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                if (!await _channel.Reader.WaitToReadAsync(cancellationToken))
+                    return false;
+
+                Current = await _channel.Reader.ReadAsync(cancellationToken);
+                return true;
+            }
+
+            public Task CompleteAsync()
+            {
+                _channel.Writer.Complete();
+                return Task.CompletedTask;
+            }
+        }
+
+        private readonly MockServiceBinder _serviceBinder;
+
+        public MockCallInvoker(MockServiceBinder serviceBinder)
+        {
+            _serviceBinder = serviceBinder;
+        }
+
+        public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method,
+            string host, CallOptions options, TRequest request)
+        {
+            if (!_serviceBinder.Handlers.TryGetValue(method.FullName, out var handler))
+                throw new InvalidOperationException($"Unknown method {method.FullName}");
+
+            ServerCallContext context = new MockServerCallContext();
+            var task = ((UnaryServerMethod<TRequest, TResponse>)handler).Invoke(request, context);
+            return task.Result;
+        }
+
+        public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
+        {
+            if (!_serviceBinder.Handlers.TryGetValue(method.FullName, out var handler))
+                throw new InvalidOperationException($"Unknown method {method.FullName}");
+
+            ServerCallContext context = new MockServerCallContext();
+            var task = ((UnaryServerMethod<TRequest, TResponse>)handler).Invoke(request, context);
+            return new AsyncUnaryCall<TResponse>(task, Task.FromResult(new Metadata()),
+                () => new Status(), () => new Metadata(), () => { });
+        }
+
+        public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, string host, CallOptions options,
+            TRequest request)
+        {
+            if (!_serviceBinder.Handlers.TryGetValue(method.FullName, out var handler))
+                throw new InvalidOperationException($"Unknown method {method.FullName}");
+
+            PassThroughStream<TResponse> stream = new PassThroughStream<TResponse>();
+            ServerCallContext context = new MockServerCallContext();
+            ((ServerStreamingServerMethod<TRequest, TResponse>)handler).Invoke(request, stream, context);
+            return new AsyncServerStreamingCall<TResponse>(stream, Task.FromResult(new Metadata()),
+                () => new Status(), () => new Metadata(), () => { });
+        }
+
+        public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, string host, CallOptions options)
+        {
+            if (!_serviceBinder.Handlers.TryGetValue(method.FullName, out var handler))
+                throw new InvalidOperationException($"Unknown method {method.FullName}");
+
+            PassThroughStream<TRequest> stream = new PassThroughStream<TRequest>();
+            ServerCallContext context = new MockServerCallContext();
+            var task = ((ClientStreamingServerMethod<TRequest, TResponse>)handler).Invoke(stream, context);
+            return new AsyncClientStreamingCall<TRequest, TResponse>(stream, task,Task.FromResult(new Metadata()),
+                () => new Status(), () => new Metadata(), () => { });
+        }
+
+        public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method, string host, CallOptions options)
+        {
+            if (!_serviceBinder.Handlers.TryGetValue(method.FullName, out var handler))
+                throw new InvalidOperationException($"Unknown method {method.FullName}");
+
+            PassThroughStream<TRequest> requestStream = new PassThroughStream<TRequest>();
+            PassThroughStream<TResponse> replyStream = new PassThroughStream<TResponse>();
+            ServerCallContext context = new MockServerCallContext();
+            ((DuplexStreamingServerMethod<TRequest, TResponse>)handler).Invoke(requestStream, replyStream, context);
+            return new AsyncDuplexStreamingCall<TRequest, TResponse>(requestStream, replyStream,Task.FromResult(new Metadata()),
+                () => new Status(), () => new Metadata(), () => { });
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/MockServiceBinder.cs
+++ b/tests/protobuf-net.Grpc.Test/MockServiceBinder.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Grpc.Core;
+
+namespace protobuf_net.Grpc.Test
+{
+    public class MockServiceBinder : ServiceBinderBase
+    {
+        public Dictionary<string, Delegate> Handlers { get; } = new Dictionary<string, Delegate>();
+
+        public override void AddMethod<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            UnaryServerMethod<TRequest, TResponse> handler)
+        {
+            Handlers.Add(method.FullName, handler);
+        }
+
+        public override void AddMethod<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            ClientStreamingServerMethod<TRequest, TResponse> handler)
+        {
+            Handlers.Add(method.FullName, handler);
+        }
+
+        public override void AddMethod<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            ServerStreamingServerMethod<TRequest, TResponse> handler)
+        {
+            Handlers.Add(method.FullName, handler);
+        }
+
+        public override void AddMethod<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            DuplexStreamingServerMethod<TRequest, TResponse> handler)
+        {
+            Handlers.Add(method.FullName, handler);
+        }
+    }
+}


### PR DESCRIPTION
A great use of the code-first approach offered by `protobuf-net.Grpc` is the ability to smoothly migrate from a WCF-based service architecture to a gRPC one, with as less code change as possible.

There are currently two major incompatibilities when trying to use existing `ServiceContract` interfaces : handling of operations with multiple parameters (#38), and of value types (especially non-string primitive types such as numeric types, and structs such as DateTime), see #27.

This PR proposes to handle these cases by wrapping things into `System.Tuple`s when appropriate.