### PR TITLE
improve metadata discovery; implement basic client

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.0.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
   }
 }

--- a/src/protobuf-net.Grpc.Native/Server/ServiceDefinitionCollectionExtensions.cs
+++ b/src/protobuf-net.Grpc.Native/Server/ServiceDefinitionCollectionExtensions.cs
@@ -66,12 +66,12 @@ namespace ProtoBuf.Grpc.Server
             protected override void OnWarn(string message, object?[]? args = null)
                 => _log?.WriteLine("[warning] " + message, args ?? Array.Empty<object>());
 
-            protected override bool TryBind<TService, TRequest, TResponse>(object state, Method<TRequest, TResponse> method, MethodStub<TService> stub)
+            protected override bool TryBind<TService, TRequest, TResponse>(ServiceBindContext bindContext, Method<TRequest, TResponse> method, MethodStub<TService> stub)
                 where TService : class
                 where TRequest : class
                 where TResponse : class
             {
-                var builder = (ServerServiceDefinition.Builder)state;
+                var builder = (ServerServiceDefinition.Builder)bindContext.State;
                 switch (method.Type)
                 {
                     case MethodType.Unary:

--- a/src/protobuf-net.Grpc/Client/GrpcClient.cs
+++ b/src/protobuf-net.Grpc/Client/GrpcClient.cs
@@ -1,0 +1,110 @@
+﻿using Grpc.Core;
+using ProtoBuf.Grpc.Configuration;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace ProtoBuf.Grpc.Client
+{
+    /// <summary>
+    /// A general purpose client for calling arbitrary gRPC methods without
+    /// any prior contract knowledge or runtime proxy generation
+    /// </summary>
+    public sealed class GrpcClient
+    {
+        /// <summary>
+        /// Returns the service name of this client
+        /// </summary>
+        public override string ToString() => _serviceName;
+
+        private readonly CallInvoker _callInvoker;
+        private readonly string _serviceName;
+        private readonly BinderConfiguration _binderConfiguration;
+
+        /// <summary>
+        /// Create a new client instance for the specified service
+        /// </summary>
+        public GrpcClient(ChannelBase channel, string serviceName, BinderConfiguration? binderConfiguration = null)
+            : this(channel.CreateCallInvoker(), serviceName, binderConfiguration) { }
+        /// <summary>
+        /// Create a new client instance for the specified service
+        /// </summary>
+        public GrpcClient(CallInvoker callInvoker, string serviceName, BinderConfiguration? binderConfiguration = null)
+        {
+            _binderConfiguration = binderConfiguration ?? BinderConfiguration.Default;
+            if (string.IsNullOrWhiteSpace(serviceName)) throw new ArgumentException(nameof(serviceName));
+            _serviceName = serviceName;
+            _callInvoker = callInvoker;
+        }
+        /// <summary>
+        /// Create a new client instance for the specified service, inferring the service name from the type
+        /// </summary>
+        public GrpcClient(ChannelBase channel, Type contractType, BinderConfiguration? binderConfiguration = null)
+            : this(channel.CreateCallInvoker(), GetServiceName(contractType, binderConfiguration), binderConfiguration) { }
+        /// <summary>
+        /// Create a new client instance for the specified service, inferring the service name from the type
+        /// </summary>
+        public GrpcClient(CallInvoker callInvoker, Type contractType, BinderConfiguration? binderConfiguration = null)
+            : this(callInvoker, GetServiceName(contractType, binderConfiguration), binderConfiguration) { }
+
+        /// <summary>
+        /// Invoke the specified gRPC method
+        /// </summary>
+        public async Task<TResponse> UnaryAsync<TRequest, TResponse>(TRequest request, string methodName,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+        {
+            var marshaller = _binderConfiguration.MarshallerCache;
+            var method = new Method<TRequest, TResponse>(MethodType.Unary, _serviceName, methodName,
+                marshaller.GetMarshaller<TRequest>(), marshaller.GetMarshaller<TResponse>());
+            using var call = _callInvoker.AsyncUnaryCall(method, host, options, request);
+            return await call.ResponseAsync.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Invoke the specified gRPC method
+        /// </summary>
+        public TResponse BlockingUnary<TRequest, TResponse>(TRequest request, string methodName,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+        {
+            var marshaller = _binderConfiguration.MarshallerCache;
+            var method = new Method<TRequest, TResponse>(MethodType.Unary, _serviceName, methodName,
+                marshaller.GetMarshaller<TRequest>(), marshaller.GetMarshaller<TResponse>());
+            return _callInvoker.BlockingUnaryCall(method, host, options, request);
+        }
+
+        /// <summary>
+        /// Invoke the specified gRPC method, inferring the operation name from the method
+        /// </summary>
+        public Task<TResponse> UnaryAsync<TRequest, TResponse>(TRequest request, MethodInfo method,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+            => UnaryAsync<TRequest, TResponse>(request, GetOperationName(method), options, host);
+        /// <summary>
+        /// Invoke the specified gRPC method, inferring the operation name from the method
+        /// </summary>
+        public TResponse BlockingUnary<TRequest, TResponse>(TRequest request, MethodInfo method,
+            CallOptions options = default, string? host = null)
+            where TRequest : class
+            where TResponse : class
+            => BlockingUnary<TRequest, TResponse>(request, GetOperationName(method), options, host);
+
+        private static string GetServiceName(Type contractType, BinderConfiguration? binderConfiguration)
+        {
+            binderConfiguration ??= BinderConfiguration.Default;
+            if (!binderConfiguration.Binder.IsServiceContract(contractType, out var name))
+                throw new InvalidOperationException("Invalid service type: " + contractType.FullName);
+            return name!;
+        }
+        private string GetOperationName(MethodInfo method)
+        {
+            if (!_binderConfiguration.Binder.IsOperationContract(method, out var name))
+                throw new InvalidOperationException("Invalid operation: " + method.Name);
+            return name!;
+        }
+    }
+}

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -212,6 +212,9 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         protected internal sealed class ServiceBindContext
         {
+            /// <summary>
+            /// The caller-provided state for this operation
+            /// </summary>
             public object State { get; }
             /// <summary>
             /// The service contract interface type

--- a/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
@@ -53,7 +53,7 @@ namespace protobuf_net.Grpc.Test.Integration
             {
                 Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }
             };
-            int opCount = _server.Services.AddCodeFirst(new ApplyServices());
+            _ = _server.Services.AddCodeFirst(new ApplyServices());
             _server.Start();
         }
 
@@ -65,7 +65,7 @@ namespace protobuf_net.Grpc.Test.Integration
     
     public class GrpcServiceTests : IClassFixture<GrpcServiceFixture>
     {
-        private GrpcServiceFixture _fixture;
+        private readonly GrpcServiceFixture _fixture;
         public GrpcServiceTests(GrpcServiceFixture fixture) => _fixture = fixture;
 
         [Fact]
@@ -103,10 +103,8 @@ namespace protobuf_net.Grpc.Test.Integration
         {
             var method = new Method<TRequest, TResponse>(MethodType.Unary, serviceName, methodName,
                 CustomMarshaller<TRequest>.Instance, CustomMarshaller<TResponse>.Instance);
-            using (var auc = invoker.AsyncUnaryCall(method, host, options, request))
-            {
-                return await auc.ResponseAsync;
-            }
+            using var auc = invoker.AsyncUnaryCall(method, host, options, request);
+            return await auc.ResponseAsync;
         }
         
         class CustomMarshaller<T> : Marshaller<T>
@@ -116,18 +114,14 @@ namespace protobuf_net.Grpc.Test.Integration
 
             private static T Deserialize(byte[] payload)
             {
-                using (var ms = new MemoryStream(payload))
-                {
-                    return ProtoBuf.Serializer.Deserialize<T>(ms);
-                }
+                using var ms = new MemoryStream(payload);
+                return ProtoBuf.Serializer.Deserialize<T>(ms);
             }
             private static byte[] Serialize(T payload)
             {
-                using (var ms = new MemoryStream())
-                {
-                    ProtoBuf.Serializer.Serialize<T>(ms, payload);
-                    return ms.ToArray();
-                }
+                using var ms = new MemoryStream();
+                ProtoBuf.Serializer.Serialize<T>(ms, payload);
+                return ms.ToArray();
             }
         }
     }    

--- a/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
+++ b/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <RootNamespace>protobuf_net.Grpc.Test.Integration</RootNamespace>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <IsPackable>false</IsPackable>
@@ -19,7 +19,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
     </ItemGroup>
 

--- a/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
+++ b/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
@@ -43,14 +43,11 @@ namespace protobuf_net.Grpc.Test
 
     public class AttributeDetection
     {
-        // note that GetAttributes lists "base" *last*; this is consistent with dotnet-grpc, although personally
-        // I'd want the order to be:
-        // "Interface,BaseType,Service,ImplicitInterfaceMethod,ImplicitServiceMethodBase,ImplicitServiceMethodOverride")]
         [Theory]
         [InlineData(nameof(ISomeService.Implicit),
-            "Interface,Service,BaseType,ImplicitInterfaceMethod,ImplicitServiceMethodOverride,ImplicitServiceMethodBase")]
+            "Interface,ImplicitInterfaceMethod,BaseType,Service,ImplicitServiceMethodBase,ImplicitServiceMethodOverride")]
         [InlineData(nameof(ISomeService.Explicit),
-            "Interface,Service,BaseType,ExplicitInterfaceMethod,ExplicitServiceMethod")]
+            "Interface,ExplicitInterfaceMethod,BaseType,Service,ExplicitServiceMethod")]
         public void AttributesDetectedWherever(string methodName, string expected)
         {
             var ctx = new ServiceBindContext(typeof(ISomeService), typeof(SomeServer), "n/a");

--- a/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
+++ b/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
@@ -1,0 +1,63 @@
+﻿using ProtoBuf.Grpc.Configuration;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static ProtoBuf.Grpc.Configuration.ServerBinder;
+
+namespace protobuf_net.Grpc.Test
+{
+
+    [AttributeUsage(AttributeTargets.All, Inherited = true, AllowMultiple = true)]
+    public class SomethingAttribute : Attribute
+    {
+        public string Value { get; }
+        public SomethingAttribute(string value)
+            => Value = value;
+    }
+
+    [Something("Interface")]
+    public interface ISomeService
+    {
+        [Something("ImplicitInterfaceMethod")]
+        ValueTask Implicit();
+        [Something("ExplicitInterfaceMethod")]
+        ValueTask Explicit();
+    }
+    [Something("BaseType")]
+    public class BaseService
+    {
+        [Something("ImplicitServiceMethodBase")]
+        public virtual ValueTask Implicit() => default;
+
+    }
+    [Something("Service")]
+    public class SomeServer : BaseService, ISomeService
+    {
+        [Something("ImplicitServiceMethodOverride")]
+        public override ValueTask Implicit() => default;
+
+        [Something("ExplicitServiceMethod")]
+        ValueTask ISomeService.Explicit() => default;
+    }
+
+    public class AttributeDetection
+    {
+        // note that GetAttributes lists "base" *last*; this is consistent with dotnet-grpc, although personally
+        // I'd want the order to be:
+        // "Interface,BaseType,Service,ImplicitInterfaceMethod,ImplicitServiceMethodBase,ImplicitServiceMethodOverride")]
+        [Theory]
+        [InlineData(nameof(ISomeService.Implicit),
+            "Interface,Service,BaseType,ImplicitInterfaceMethod,ImplicitServiceMethodOverride,ImplicitServiceMethodBase")]
+        [InlineData(nameof(ISomeService.Explicit),
+            "Interface,Service,BaseType,ExplicitInterfaceMethod,ExplicitServiceMethod")]
+        public void AttributesDetectedWherever(string methodName, string expected)
+        {
+            var ctx = new ServiceBindContext(typeof(ISomeService), typeof(SomeServer), "n/a");
+            var method = typeof(ISomeService).GetMethod(methodName)!;
+            var actual = string.Join(",", ctx.GetMetadata(method).OfType<SomethingAttribute>().Select(x => x.Value));
+            Assert.Equal(expected, actual);
+
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
+++ b/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Test</RootNamespace>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
metadata discovery now includes:

- service contract (interface)
- service type (class)
- operation contract (interface method)
- operation implementation (class method)

this should enable [Authorize] etc in all scenarios
impacts #39 (also #67); 

---

Also adds `GrpcClient` for basic usage scenarios