### PR TITLE
Use linker-friendly attribute metadata inspection

### DIFF
--- a/src/protobuf-net.Grpc/Internal/AttributeHelper.cs
+++ b/src/protobuf-net.Grpc/Internal/AttributeHelper.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace ProtoBuf.Grpc.Internal
+{
+    internal readonly struct AttributeHelper
+    {
+        private readonly IList<CustomAttributeData>? _attribs;
+        public static AttributeHelper For(Type type, bool inherit)
+        {
+            IList<CustomAttributeData>? attribs = null;
+            while (type is object)
+            {
+                Append(ref attribs, type.GetCustomAttributesData());
+                type = (inherit ? type.BaseType : null)!;
+            }
+            
+            return new AttributeHelper(attribs);
+        }
+
+        private static void Append(ref IList<CustomAttributeData>? attribs, IList<CustomAttributeData> local)
+        {
+            if (local is null || local.Count == 0) return;
+            
+            if (attribs is null)
+            {
+                attribs = local;
+            }
+            else if (attribs is List<CustomAttributeData> hardList)
+            {
+                hardList.AddRange(local);
+            }
+            else
+            {
+                var newList = new List<CustomAttributeData>(attribs.Count + local.Count);
+                newList.AddRange(attribs);
+                newList.AddRange(local);
+                attribs = newList;
+            }
+        }
+        private AttributeHelper(IList<CustomAttributeData>? attribs)
+        {
+            if (attribs is object && attribs.Count == 0)
+            {
+                attribs = null;
+            }
+            _attribs = attribs;
+        }
+
+        public static AttributeHelper For(MethodInfo method, bool inherit)
+        {
+            IList<CustomAttributeData>? attribs = null;
+            while (method is object)
+            {
+                Append(ref attribs, method.GetCustomAttributesData());
+                method = (inherit ? GetAncestor(method) : null)!;
+            }
+            return new AttributeHelper(attribs);
+        }
+
+        static MethodInfo? GetAncestor(MethodInfo method)
+        {
+            if (method is null || method.IsStatic) return null;
+            var baseMethod = method.GetBaseDefinition();
+            var type = method.DeclaringType;
+            if (type is null || type == baseMethod.DeclaringType) return null;
+
+            var parentMethods = type.BaseType?.GetMethods((method.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic) | BindingFlags.Instance)
+                ?? Array.Empty<MethodInfo>();
+            foreach (var parentMethod in parentMethods)
+            {
+                if (parentMethod.GetBaseDefinition() == baseMethod) return parentMethod;
+            }
+            return null;
+        }
+
+        public bool TryGetNamedArgument(string typeName, string name, out CustomAttributeTypedArgument value)
+            => TryGet(typeName, name, true, false, out value);
+        public bool TryGetConstructorParameter(string typeName, string name, out CustomAttributeTypedArgument value)
+            => TryGet(typeName, name, false, true, out value);
+        public bool TryGetAny(string typeName, string name, out CustomAttributeTypedArgument value)
+            => TryGet(typeName, name, true, true, out value);
+
+        internal bool TryGetAnyNonWhitespaceString(string typeName, string name, out string value)
+        {
+            if (TryGetAny(typeName, name, out var cata) && cata.Value is string typed)
+            {
+                value = typed;
+                return !string.IsNullOrWhiteSpace(value);
+            }
+            value = "";
+            return false;
+        }
+
+
+        public bool IsDefined(string typeName)
+        {
+            foreach (var attrib in _attribs ?? Array.Empty<CustomAttributeData>())
+            {
+                if (attrib.AttributeType.FullName == typeName) return true;
+            }
+            return false;
+        }
+
+        private bool TryGet(string typeName, string name, bool tryNamedArgument, bool tryConstructorParam, out CustomAttributeTypedArgument value)
+        {
+            foreach (var attrib in _attribs ?? Array.Empty<CustomAttributeData>())
+            {
+                if (attrib.AttributeType.FullName == typeName)
+                {
+                    if (tryNamedArgument)
+                    {
+                        foreach (var named in attrib.NamedArguments)
+                        {
+                            if (string.Equals(named.MemberName, name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                value = named.TypedValue;
+                                return true;
+                            }
+                        }
+                    }
+
+                    if (tryConstructorParam)
+                    {
+                        var ctorParams = attrib.Constructor.GetParameters();
+                        for (int i = 0; i < ctorParams.Length; i++)
+                        {
+                            if (string.Equals(ctorParams[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                value = attrib.ConstructorArguments[i];
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            value = default;
+            return false;
+        }
+    }
+}

--- a/src/protobuf-net.Grpc/PushEnumerable.cs
+++ b/src/protobuf-net.Grpc/PushEnumerable.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ProtoBuf.Grpc
+{
+    /// <summary>
+    /// Defines a non-buffered push API that represents async enumerable data
+    /// </summary>
+    public interface IPushAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+        /// <summary>
+        /// Indicates whether this sequence is completed
+        /// </summary>
+        bool IsCompleted { get; }
+        /// <summary>
+        /// Indicates the end of the sequence
+        /// </summary>
+        void Complete(Exception? error = null);
+        /// <summary>
+        /// Sends an element to the sequence and awaits its consumption
+        /// </summary>
+        ValueTask PushAsync(T value, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Allows construction of <see cref="IPushAsyncEnumerable{T}"/> instances
+    /// </summary>
+    public static class PushAsyncEnumerable
+    {
+        /// <summary>
+        /// Create a new <see cref="IPushAsyncEnumerable{T}"/> instance
+        /// </summary>
+        public static IPushAsyncEnumerable<T> Create<T>() => new PushAsyncEnumerableCore<T>();
+
+        static readonly Exception
+            s_DisposedSentinel = new ObjectDisposedException(nameof(PushAsyncEnumerable)),
+            s_CanceledSentinel = new TaskCanceledException();
+
+        private static readonly Action<object> s_CancelCallback = s => (s as ICancellableInner)?.Cancel();
+
+        private interface ICancellableInner
+        {
+            void Cancel();
+        }
+        private sealed class PushAsyncEnumerableCore<T> : ICancellableInner,
+            IPushAsyncEnumerable<T>, IAsyncEnumerator<T>,
+            IValueTaskSource<bool>, IValueTaskSource<int>
+        {
+            ManualResetValueTaskSourceCore<bool> _moveNext;
+            ManualResetValueTaskSourceCore<int> _consumed;
+            CancellationTokenRegistration _cancellationTokenRegistration;
+            private bool _isCompleted;
+            public bool IsCompleted => _isCompleted;
+
+            private void SetCompleted([CallerMemberName] string caller = "")
+            {
+                if (!_isCompleted)
+                {
+                    Debug.WriteLine($"{nameof(PushAsyncEnumerable)}<{typeof(T).Name}> completed by {caller}");
+                }
+                _isCompleted = true;
+            }
+            public PushAsyncEnumerableCore()
+            {
+                _current = default!;
+                _moveNext.RunContinuationsAsynchronously = false;
+            }
+
+            private T _current;
+            T IAsyncEnumerator<T>.Current => _current;
+
+            ValueTask IAsyncDisposable.DisposeAsync()
+            {
+                SetCompleted();
+                try
+                {
+                    _moveNext.SetException(s_DisposedSentinel);
+                }
+                catch { }
+                try
+                {
+                    _consumed.SetResult(0);
+                }
+                catch { }
+                var tmp = _cancellationTokenRegistration;
+                _cancellationTokenRegistration = default;
+                try
+                {
+                    tmp.Dispose();
+                }
+                catch { }
+                return default;
+            }
+
+            public void Complete(Exception? error = null)
+            {
+                SetCompleted();
+                if (error is null)
+                {
+                    _moveNext.SetResult(false);
+                    _consumed.SetResult(0);
+                }
+                else
+                {
+                    try { _moveNext.SetException(error); }
+                    catch { }
+                    try { _consumed.SetException(error); }
+                    catch { }
+                }
+            }
+
+            void ICancellableInner.Cancel()
+            {
+                SetCompleted();
+                try
+                {
+                    _moveNext.SetException(s_CanceledSentinel);
+                }
+                catch { }
+                try
+                {
+                    _consumed.SetException(s_CanceledSentinel);
+                }
+                catch { }
+            }
+
+            public ValueTask PushAsync(T value, CancellationToken cancellationToken = default)
+            {
+                _consumed.Reset();
+                var consumed = new ValueTask<int>(this, _consumed.Version);
+                _current = value;
+                _moveNext.SetResult(true);
+                return consumed.IsCompletedSuccessfully ? default
+                    : AwaitConsumed(consumed, cancellationToken);
+            }
+
+            private async ValueTask AwaitConsumed(ValueTask<int> consumed, CancellationToken cancellationToken)
+            {
+                using (cancellationToken.Register(s_CancelCallback, this, false))
+                {
+                    try
+                    {
+                        await consumed.ConfigureAwait(false);
+                    }
+                    catch(ObjectDisposedException ode) when (ReferenceEquals(ode, s_DisposedSentinel))
+                    {
+                        ThrowDisposed();
+                    }
+                }
+            }
+
+            private void ThrowDisposed()
+                => throw new ObjectDisposedException(nameof(PushAsyncEnumerable));
+
+            IAsyncEnumerator<T> IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken cancellationToken)
+            {
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    _cancellationTokenRegistration = cancellationToken.Register(s_CancelCallback, this, false);
+                }
+                return this;
+            }
+
+            ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()
+            {
+                _consumed.SetResult(0);
+                _moveNext.Reset();
+                return new ValueTask<bool>(this, _moveNext.Version);
+            }
+
+            bool IValueTaskSource<bool>.GetResult(short token)
+            {
+                try
+                {
+                    return _moveNext.GetResult(token);
+                }
+                catch (TaskCanceledException tce) when (ReferenceEquals(tce, s_CanceledSentinel))
+                {   // don't want to expose the singletons we used earlier
+                    throw new TaskCanceledException();
+                }
+                catch (ObjectDisposedException ode) when (ReferenceEquals(ode, s_DisposedSentinel))
+                {   // don't want to expose the singletons we used earlier
+                    ThrowDisposed();
+                    return default; // for compiler
+                }
+            }
+
+            ValueTaskSourceStatus IValueTaskSource<bool>.GetStatus(short token) => _moveNext.GetStatus(token);
+
+            void IValueTaskSource<bool>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+                => _moveNext.OnCompleted(continuation, state, token, flags);
+
+            int IValueTaskSource<int>.GetResult(short token) => _consumed.GetResult(token);
+
+            ValueTaskSourceStatus IValueTaskSource<int>.GetStatus(short token) => _consumed.GetStatus(token);
+
+            void IValueTaskSource<int>.OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+                => _consumed.OnCompleted(continuation, state, token, flags);
+        }
+    }
+}

--- a/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
+++ b/tests/protobuf-net.Grpc.Test/AttributeDetection.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf.Grpc.Configuration;
+﻿using ProtoBuf.Grpc.Internal;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,5 +56,118 @@ namespace protobuf_net.Grpc.Test
             Assert.Equal(expected, actual);
 
         }
+
+        [Theory]
+        [InlineData(typeof(SomeBaseType), true, "base", "base bar")]
+        [InlineData(typeof(SomeMiddleType), true, "middle", "base bar")]
+        [InlineData(typeof(SomeLeafType), true, "leaf", "base bar")]
+        [InlineData(typeof(SomeBaseType), false, "base", "base bar")]
+        [InlineData(typeof(SomeMiddleType), false, "middle", null)]
+        [InlineData(typeof(SomeLeafType), false, "leaf", null)]
+        public void CheckTypeAttributes(Type type, bool inherit, string expectedFoo, string expectedBar)
+            => CheckResults(AttributeHelper.For(type, inherit), expectedFoo, expectedBar);
+        private static void CheckResults(AttributeHelper attribs, string expectedFoo, string expectedBar)
+        {
+            var fooResult = attribs.TryGetAnyNonWhitespaceString(typeof(FooAttribute).FullName, "Name", out var actualFoo);
+            var barResult = attribs.TryGetAnyNonWhitespaceString(typeof(BarAttribute).FullName, "Name", out var actualBar);
+
+            if (string.IsNullOrWhiteSpace(expectedFoo))
+            {
+                Assert.False(fooResult);
+            }
+            else
+            {
+                Assert.True(fooResult);
+                Assert.Equal(expectedFoo, actualFoo);
+            }
+            if (string.IsNullOrWhiteSpace(expectedBar))
+            {
+                Assert.False(barResult);
+            }
+            else
+            {
+                Assert.True(barResult);
+                Assert.Equal(expectedBar, actualBar);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(SomeBaseType), "A", true, "a base", "a base bar")]
+        [InlineData(typeof(SomeBaseType), "B", true, "b base", "b base bar")]
+        [InlineData(typeof(SomeBaseType), "C", true, "c base", "c base bar")]
+        [InlineData(typeof(SomeMiddleType), "A", true, "a middle", "a base bar")]
+        [InlineData(typeof(SomeMiddleType), "B", true, "b base", "b base bar")]
+        [InlineData(typeof(SomeMiddleType), "C", true, "c middle", "c base bar")]
+        [InlineData(typeof(SomeLeafType), "A", true, "a middle", "a base bar")]
+        [InlineData(typeof(SomeLeafType), "B", true, "b leaf", "b base bar")]
+        [InlineData(typeof(SomeLeafType), "C", true, "c leaf", "c base bar")]
+
+        [InlineData(typeof(SomeBaseType), "A", false, "a base", "a base bar")]
+        [InlineData(typeof(SomeBaseType), "B", false, "b base", "b base bar")]
+        [InlineData(typeof(SomeBaseType), "C", false, "c base", "c base bar")]
+        [InlineData(typeof(SomeMiddleType), "A", false, "a middle", null)]
+        [InlineData(typeof(SomeMiddleType), "B", false, "b base", "b base bar")]
+        [InlineData(typeof(SomeMiddleType), "C", false, "c middle", null)]
+        [InlineData(typeof(SomeLeafType), "A", false, "a middle", null)]
+        [InlineData(typeof(SomeLeafType), "B", false, "b leaf", null)]
+        [InlineData(typeof(SomeLeafType), "C", false, "c leaf", null)]
+
+        [InlineData(typeof(SomeBaseType), "D", true, null, null)]
+        [InlineData(typeof(SomeMiddleType), "D", true, null, null)]
+        [InlineData(typeof(SomeLeafType), "D", true, null, null)]
+        [InlineData(typeof(SomeBaseType), "D", false, null, null)]
+        [InlineData(typeof(SomeMiddleType), "D", false, null, null)]
+        [InlineData(typeof(SomeLeafType), "D", false, null, null)]
+
+        public void CheckMethodAttributes(Type type, string method, bool inherit, string expectedFoo, string expectedBar)
+            => CheckResults(AttributeHelper.For(type.GetMethod(method), inherit), expectedFoo, expectedBar);
+
+        [Foo("base")]
+        [Bar("base bar")]
+        public class SomeBaseType
+        {
+            [Foo("a base")]
+            [Bar("a base bar")]
+            public virtual void A() { }
+            [Foo("b base")]
+            [Bar("b base bar")]
+            public virtual void B() { }
+            [Foo("c base")]
+            [Bar("c base bar")]
+            public virtual void C() { }
+        }
+        [Foo("middle")]
+        public class SomeMiddleType : SomeBaseType
+        {
+            [Foo("a middle")]
+            public override void A() { }
+            [Foo("c middle")]
+            public override void C() { }
+        }
+        [Foo("leaf")]
+        public class SomeLeafType : SomeMiddleType
+        {
+            [Foo("b leaf")]
+            public override void B() { }
+            [Foo("c leaf")]
+            public override void C() { }
+        }
+
+        public class FooAttribute : Attribute
+        {
+            public string Name { get; set; }
+            public FooAttribute() { Name = ""; }
+            public FooAttribute(string name) { Name = name; }
+        }
+
+        public class BarAttribute : Attribute
+        {
+            public string Name { get; set; }
+            public BarAttribute() { Name = ""; }
+            public BarAttribute(string name) { Name = name; }
+        }
     }
+
+    
+
 }

--- a/toys/PlayClient/Program.cs
+++ b/toys/PlayClient/Program.cs
@@ -224,7 +224,9 @@ namespace PlayClient
                 {
                     var n = 0;
                     while (!target.IsCompleted)
-                    {
+                    {   // note: normally the caller would also use .Complete etc,
+                        // but in this example we're looping until we're told not to
+
                         var request = new BidiStreamingRequest { Payload = $"Payload {n++}" };
                         Console.WriteLine($"Sending request with payload: {request.Payload}");
 

--- a/toys/PlayServer/Program.cs
+++ b/toys/PlayServer/Program.cs
@@ -86,13 +86,13 @@ internal class MyServer : ICalculator, IDuplex, IBidiStreamingService
         await Task.Yield();
         Console.WriteLine("STARTING. TestAsync method call received.");
         //if (Always()) throw new InvalidOperationException("oops");
-        //for (int i = 0; i < 2; i++)
-        //{
-        //    await Task.Delay(500, context.CancellationToken);
-        //    yield return new BidiStreamingResponse { Payload = $"response {i}" };
-        //}
+        for (int i = 0; i < 5; i++)
+        {
+            await Task.Delay(500, context.CancellationToken);
+            yield return new BidiStreamingResponse { Payload = $"response {i}" };
+        }
 
         //static bool Always() => true;
-        yield break;
+       // yield break;
     }
 }


### PR DESCRIPTION
Related to #90

If we rely on *materializing* the attributes, there's a chance the linker (Blazor etc) has removed the implementations; we can instead try to use an alternative inspection API that doesn't materialize them - it just looks at the metadata. Then: it doesn't matter what the linker does.

Note: we don't use this in the server-side binder, as the underlying gRPC tools rely on receiving materialized attributes.