### PR TITLE
support CancellationToken signatures

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,3 +70,5 @@ var options = new CallOptions(...);
 // invoke the RPC call
 var result = await client.SearchAsync(request, options);
 ```
+
+(note that a `CancellationToken` can be used in place of `CallContext` above to express optional cancellation; this is a more general purpose API, but does not permit access to headers/trailers/etc).

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -115,6 +115,18 @@ public interface ICalculator
 }
 ```
 
+If you wish to allow optional cancellation in a general purpose way, and do *not* require access to headers/trailers/etc, then you can use `CancellationToken` in
+place of `CallContext`:
+
+``` c#
+[ServiceContract(Name = "Hyper.Calculator")]
+public interface ICalculator
+{
+    ValueTask<MultiplyResult> MultiplyAsync(MultiplyRequest request, CancellationToken cancellationToken = default);
+}
+```
+
+
 If you want to use client/server-streaming or duplex communication, then instead of using `T`, `Task<T>` etc, you can use `IAsyncEnumerable<T>` for
 either the data parameter or the return type. For example, we could subscribe to a speaking clock via:
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## (unreleased)
+
+- support `CancellationToken` in service signatures in place of `CallContext` (#95)
+
 ## 1.0.75
 
 - addition of [`ClientFactory`](https://www.nuget.org/packages/protobuf-net.Grpc.ClientFactory) support

--- a/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
@@ -867,7 +867,7 @@ namespace protobuf_net.Grpc.Test.Integration
         }
 
         [Fact]
-        public async Task UnaryCancelViaToken()
+        public async Task UnaryDelayCancelViaToken()
         {
             await using var svc = CreateClient(out var client);
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
@@ -881,7 +881,19 @@ namespace protobuf_net.Grpc.Test.Integration
             { }
             var taken = DateTime.UtcNow - start;
             _fixture.Log($"client: {taken}");
-            Assert.True(taken < TimeSpan.FromSeconds(1.5));
+            Assert.True(taken > TimeSpan.FromSeconds(0.8) && taken < TimeSpan.FromSeconds(1.5));
+        }
+
+        [Fact]
+        public async Task UnaryDelayCompletionWithoutToken()
+        {
+            await using var svc = CreateClient(out var client);
+            var start = DateTime.UtcNow;
+
+            await client.TakeFive();
+            var taken = DateTime.UtcNow - start;
+            _fixture.Log($"client: {taken}");
+            Assert.True(taken > TimeSpan.FromSeconds(4.8) && taken < TimeSpan.FromSeconds(5.5));
         }
     }
 }

--- a/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
+++ b/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
@@ -52,13 +52,13 @@ namespace protobuf_net.Grpc.Test
         [Fact]
         public void GeneralPurposeSignatureCount()
         {
-            Assert.Equal(38, ContractOperation.GeneralPurposeSignatureCount());
+            Assert.Equal(57, ContractOperation.GeneralPurposeSignatureCount());
         }
 
         [Fact]
         public void ServerSignatureCount()
         {
-            Assert.Equal(38, ServerInvokerLookup.GeneralPurposeSignatureCount());
+            Assert.Equal(57, ServerInvokerLookup.GeneralPurposeSignatureCount());
         }
 
         [Fact]
@@ -97,48 +97,67 @@ namespace protobuf_net.Grpc.Test
 
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Sync, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_BlockingUnary_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Sync, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_Context_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Sync, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_NoContext_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Both)]
+        [InlineData(nameof(IAllOptions.Shared_BlockingUnary_CancellationToken_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Sync, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_Context_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Sync, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_NoContext_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Request)]
+        [InlineData(nameof(IAllOptions.Shared_BlockingUnary_CancellationToken_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Sync, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_Context_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Sync, (int)VoidKind.Response)]
         [InlineData(nameof(IAllOptions.Shared_BlockingUnary_NoContext_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Sync, (int)VoidKind.Response)]
+        [InlineData(nameof(IAllOptions.Shared_BlockingUnary_CancellationToken_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Sync, (int)VoidKind.Response)]
 
         [InlineData(nameof(IAllOptions.Shared_Duplex_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.DuplexStreaming, (int)ContextKind.CallContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_Duplex_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.DuplexStreaming, (int)ContextKind.NoContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_Duplex_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.DuplexStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
 
         [InlineData(nameof(IAllOptions.Shared_ServerStreaming_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.CallContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ServerStreaming_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.NoContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_ServerStreaming_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.AsyncEnumerable, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ServerStreaming_Context_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.CallContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_ServerStreaming_NoContext_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.NoContext, (int)ResultKind.AsyncEnumerable, (int)VoidKind.Request)]
+        [InlineData(nameof(IAllOptions.Shared_ServerStreaming_CancellationToken_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.ServerStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.AsyncEnumerable, (int)VoidKind.Request)]
 
         [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_Context_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.Response)]
         [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_NoContext_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Response)]
+        [InlineData(nameof(IAllOptions.Shared_TaskClientStreaming_CancellationToken_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.Response)]
 
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_TaskUnary_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_Context_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_NoContext_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Both)]
+        [InlineData(nameof(IAllOptions.Shared_TaskUnary_CancellationToken_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_Context_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_NoContext_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Request)]
+        [InlineData(nameof(IAllOptions.Shared_TaskUnary_CancellationToken_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_Context_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.Task, (int)VoidKind.Response)]
         [InlineData(nameof(IAllOptions.Shared_TaskUnary_NoContext_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.Task, (int)VoidKind.Response)]
+        [InlineData(nameof(IAllOptions.Shared_TaskUnary_CancellationToken_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.Task, (int)VoidKind.Response)]
 
         [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.ClientStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_Context_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_NoContext_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskClientStreaming_CancellationToken_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.ClientStreaming, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
 
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_Context), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_NoContext), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.None)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_CancellationToken), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.None)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_Context_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_NoContext_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Both)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_CancellationToken_VoidVoid), typeof(Empty), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.Both)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_Context_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_NoContext_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Request)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_CancellationToken_VoidVal), typeof(Empty), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.Request)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_Context_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CallContext, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
         [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_NoContext_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.NoContext, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
+        [InlineData(nameof(IAllOptions.Shared_ValueTaskUnary_CancellationToken_ValVoid), typeof(HelloRequest), typeof(Empty), MethodType.Unary, (int)ContextKind.CancellationToken, (int)ResultKind.ValueTask, (int)VoidKind.Response)]
         public void CheckMethodIdentification(string name, Type from, Type to, MethodType methodType, int context, int result, int @void)
         {
             var method = typeof(IAllOptions).GetMethod(name);

--- a/tests/protobuf-net.Grpc.Test/IAllOptions.cs
+++ b/tests/protobuf-net.Grpc.Test/IAllOptions.cs
@@ -3,6 +3,7 @@ using ProtoBuf;
 using ProtoBuf.Grpc;
 using System.Collections.Generic;
 using System.ServiceModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace protobuf_net.Grpc.Test
@@ -41,60 +42,79 @@ namespace protobuf_net.Grpc.Test
         // blocking unary
         HelloReply Shared_BlockingUnary_NoContext(HelloRequest request);
         HelloReply Shared_BlockingUnary_Context(HelloRequest request, CallContext context);
+        HelloReply Shared_BlockingUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken);
 
         void Shared_BlockingUnary_NoContext_VoidVoid();
         void Shared_BlockingUnary_Context_VoidVoid(CallContext context);
+        void Shared_BlockingUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken);
 
         HelloReply Shared_BlockingUnary_NoContext_VoidVal();
         HelloReply Shared_BlockingUnary_Context_VoidVal(CallContext context);
+        HelloReply Shared_BlockingUnary_CancellationToken_VoidVal(CancellationToken cancellationToken);
 
         void Shared_BlockingUnary_NoContext_ValVoid(HelloRequest request);
         void Shared_BlockingUnary_Context_ValVoid(HelloRequest request, CallContext context);
+        void Shared_BlockingUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken);
 
         // async unary
         Task<HelloReply> Shared_TaskUnary_NoContext(HelloRequest request);
         Task<HelloReply> Shared_TaskUnary_Context(HelloRequest request, CallContext context);
+        Task<HelloReply> Shared_TaskUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken);
 
         Task Shared_TaskUnary_NoContext_VoidVoid();
         Task Shared_TaskUnary_Context_VoidVoid(CallContext context);
+        Task Shared_TaskUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken);
 
         Task<HelloReply> Shared_TaskUnary_NoContext_VoidVal();
         Task<HelloReply> Shared_TaskUnary_Context_VoidVal(CallContext context);
+        Task<HelloReply> Shared_TaskUnary_CancellationToken_VoidVal(CancellationToken cancellationToken);
 
         Task Shared_TaskUnary_NoContext_ValVoid(HelloRequest request);
         Task Shared_TaskUnary_Context_ValVoid(HelloRequest request, CallContext context);
+        Task Shared_TaskUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken);
 
         ValueTask<HelloReply> Shared_ValueTaskUnary_NoContext(HelloRequest request);
         ValueTask<HelloReply> Shared_ValueTaskUnary_Context(HelloRequest request, CallContext context);
+        ValueTask<HelloReply> Shared_ValueTaskUnary_CancellationToken(HelloRequest request, CancellationToken cancellationToken);
 
         ValueTask Shared_ValueTaskUnary_NoContext_VoidVoid();
         ValueTask Shared_ValueTaskUnary_Context_VoidVoid(CallContext context);
+        ValueTask Shared_ValueTaskUnary_CancellationToken_VoidVoid(CancellationToken cancellationToken);
 
         ValueTask<HelloReply> Shared_ValueTaskUnary_NoContext_VoidVal();
         ValueTask<HelloReply> Shared_ValueTaskUnary_Context_VoidVal(CallContext context);
+        ValueTask<HelloReply> Shared_ValueTaskUnary_CancellationToken_VoidVal(CancellationToken cancellationToken);
 
         ValueTask Shared_ValueTaskUnary_NoContext_ValVoid(HelloRequest request);
         ValueTask Shared_ValueTaskUnary_Context_ValVoid(HelloRequest request, CallContext context);
+        ValueTask Shared_ValueTaskUnary_CancellationToken_ValVoid(HelloRequest request, CancellationToken cancellationToken);
 
         // client-streaming
         Task<HelloReply> Shared_TaskClientStreaming_NoContext(IAsyncEnumerable<HelloRequest> request);
         Task<HelloReply> Shared_TaskClientStreaming_Context(IAsyncEnumerable<HelloRequest> request, CallContext context);
+        Task<HelloReply> Shared_TaskClientStreaming_CancellationToken(IAsyncEnumerable<HelloRequest> request, CancellationToken cancellationToken);
         Task Shared_TaskClientStreaming_NoContext_ValVoid(IAsyncEnumerable<HelloRequest> request);
         Task Shared_TaskClientStreaming_Context_ValVoid(IAsyncEnumerable<HelloRequest> request, CallContext context);
+        Task Shared_TaskClientStreaming_CancellationToken_ValVoid(IAsyncEnumerable<HelloRequest> request, CancellationToken cancellationToken);
 
         ValueTask<HelloReply> Shared_ValueTaskClientStreaming_NoContext(IAsyncEnumerable<HelloRequest> request);
         ValueTask<HelloReply> Shared_ValueTaskClientStreaming_Context(IAsyncEnumerable<HelloRequest> request, CallContext context);
+        ValueTask<HelloReply> Shared_ValueTaskClientStreaming_CancellationToken(IAsyncEnumerable<HelloRequest> request, CancellationToken cancellationToken);
         ValueTask Shared_ValueTaskClientStreaming_NoContext_ValVoid(IAsyncEnumerable<HelloRequest> request);
         ValueTask Shared_ValueTaskClientStreaming_Context_ValVoid(IAsyncEnumerable<HelloRequest> request, CallContext context);
+        ValueTask Shared_ValueTaskClientStreaming_CancellationToken_ValVoid(IAsyncEnumerable<HelloRequest> request, CancellationToken cancellationToken);
 
         // server-streaming
         IAsyncEnumerable<HelloReply> Shared_ServerStreaming_NoContext(HelloRequest request);
         IAsyncEnumerable<HelloReply> Shared_ServerStreaming_Context(HelloRequest request, CallContext context);
+        IAsyncEnumerable<HelloReply> Shared_ServerStreaming_CancellationToken(HelloRequest request, CancellationToken cancellationToken);
         IAsyncEnumerable<HelloReply> Shared_ServerStreaming_NoContext_VoidVal();
         IAsyncEnumerable<HelloReply> Shared_ServerStreaming_Context_VoidVal(CallContext context);
+        IAsyncEnumerable<HelloReply> Shared_ServerStreaming_CancellationToken_VoidVal(CancellationToken cancellationToken);
 
         // duplex
         IAsyncEnumerable<HelloReply> Shared_Duplex_NoContext(IAsyncEnumerable<HelloRequest> request);
         IAsyncEnumerable<HelloReply> Shared_Duplex_Context(IAsyncEnumerable<HelloRequest> request, CallContext context);
+        IAsyncEnumerable<HelloReply> Shared_Duplex_CancellationToken(IAsyncEnumerable<HelloRequest> request, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
 fixes #95; increases signuature options by 19

have verified that this is propagated correctly end-to-end - see `UnaryDelayCompletionWithoutToken` (no cancellation passed, server takes 5 seconds):

``` ctx
server: delay ran to completion: 00:00:05.0100884
client: 00:00:05.0306842
```

and `UnaryDelayCancelViaToken` (1 second cancellation passed, server cancels correctly)

``` ctx
server: delay cancelled: 00:00:01.0155004
client: 00:00:01.0170961
```
