### PR TITLE
Add support for configuring a custom servicebinder using fluent methods (#121)

### DIFF
--- a/examples/pb-net-grpc/Client_CS/Program.cs
+++ b/examples/pb-net-grpc/Client_CS/Program.cs
@@ -1,12 +1,12 @@
-﻿using Grpc.Core;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
 using Grpc.Net.Client;
 using MegaCorp;
 using ProtoBuf.Grpc;
 using ProtoBuf.Grpc.Client;
 using Shared_CS;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Client_CS
 {
@@ -21,6 +21,7 @@ namespace Client_CS
             Console.WriteLine(result.Result); // 48
 
             var clock = http.CreateGrpcService<ITimeService>();
+            var counter = http.CreateGrpcService<ICounter>();
             using var cancel = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             var options = new CallOptions(cancellationToken: cancel.Token);
 
@@ -29,10 +30,14 @@ namespace Client_CS
                 await foreach (var time in clock.SubscribeAsync(new CallContext(options)))
                 {
                     Console.WriteLine($"The time is now: {time.Time}");
+                    var currentInc = await counter.IncrementAsync(new IncrementRequest { Inc = 1 });
+                    Console.WriteLine($"Time recieved {currentInc.Result} times");
                 }
             }
-            catch (RpcException) { }
+            catch (RpcException ex) { Console.WriteLine(ex); }
             catch (OperationCanceledException) { }
+            Console.WriteLine("Press [Enter] to exit");
+            Console.ReadLine();
         }
     }
 }

--- a/examples/pb-net-grpc/Server_CS/FakeAuthenticationHandler.cs
+++ b/examples/pb-net-grpc/Server_CS/FakeAuthenticationHandler.cs
@@ -1,0 +1,33 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Server_CS
+{
+    class FakeAuthHandler : AuthenticationHandler<FakeAuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "Fake";
+
+        public FakeAuthHandler(
+        IOptionsMonitor<FakeAuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock)
+        : base(options, logger, encoder, clock)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var claimsIdentity = new ClaimsIdentity(SchemeName);
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(claimsIdentity), Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    class FakeAuthenticationSchemeOptions : AuthenticationSchemeOptions
+    { }
+}

--- a/examples/pb-net-grpc/Server_CS/MyCounter.cs
+++ b/examples/pb-net-grpc/Server_CS/MyCounter.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Shared_CS;
+
+namespace Server_CS
+{
+    [Authorize]
+    public class MyCounter : ICounter
+    {
+        private int counter = 0;
+        private readonly object counterLock = new object();
+
+        ValueTask<IncrementResult> ICounter.IncrementAsync(IncrementRequest request)
+        {
+            lock (counterLock)
+            {
+                counter += request.Inc;
+                var result = new IncrementResult { Result = counter };
+                return new ValueTask<IncrementResult>(result);
+            }
+        }
+    }
+}

--- a/examples/pb-net-grpc/Server_CS/Properties/launchSettings.json
+++ b/examples/pb-net-grpc/Server_CS/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Server_CS": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/examples/pb-net-grpc/Server_CS/ServiceBinderWithServiceResolutionFromServiceCollection.cs
+++ b/examples/pb-net-grpc/Server_CS/ServiceBinderWithServiceResolutionFromServiceCollection.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using ProtoBuf.Grpc.Configuration;
+
+namespace Server_CS
+{
+    internal class ServiceBinderWithServiceResolutionFromServiceCollection : ServiceBinder
+    {
+        private readonly IServiceCollection services;
+
+        public ServiceBinderWithServiceResolutionFromServiceCollection(IServiceCollection services)
+        {
+            this.services = services;
+        }
+
+        public override IList<object> GetMetadata(MethodInfo method, Type contractType, Type serviceType)
+        {
+            var resolvedServiceType = serviceType;
+            if (serviceType.IsInterface)
+                resolvedServiceType = services.SingleOrDefault(x => x.ServiceType == serviceType)?.ImplementationType ?? serviceType;
+
+            return base.GetMetadata(method, contractType, resolvedServiceType);
+        }
+    }
+}

--- a/examples/pb-net-grpc/Shared_CS/Counter.cs
+++ b/examples/pb-net-grpc/Shared_CS/Counter.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Threading.Tasks;
+namespace Shared_CS
+{
+    [ServiceContract]
+    public interface ICounter
+    {
+        ValueTask<IncrementResult> IncrementAsync(IncrementRequest request);
+    }
+
+    [DataContract]
+    public class IncrementRequest
+    {
+        [DataMember(Order = 1)]
+        public int Inc { get; set; }
+    }
+
+    [DataContract]
+    public class IncrementResult
+    {
+        [DataMember(Order = 1)]
+        public int Result { get; set; }
+    }
+}


### PR DESCRIPTION
@mgravell 
As per discussion on #121 i've prepared a PR based on moving the metadata lookup to the service binder.
I've split into 3 commits to make it easier to see the actual implementation vs an update to your example to test the scenario.

Note that I moved the entire `GetMetadata` as calling a separate `GetMetadata(MethodInfo methodInfo)` is too late as the `MethodInfo` for the service type would already be incorrect in my use case.
We could split into seperate `GetContractMetadata`() or `GetServiceMetaData()` overrides, but the method ones need the service type for me to resolve before getting the methodInfo so I didn't think it was worth it if I could resolve the ServiceType before calling the base implementation.

If you want to see it with the existing behaviour simply comment out the `.WithBinderConfiguration` line from the `Startup.cs` and it will then start ignoring the `[Authorize]` attribute in the counter service.

Let me know if you need any changes or want the test example changes dropped from the PR.

Thanks
Euan