### PR TITLE
Adjust ServicesExtensions to GrpcClientServiceExtensions

### DIFF
--- a/src/protobuf-net.Grpc.ClientFactory/ServicesExtensions.cs
+++ b/src/protobuf-net.Grpc.ClientFactory/ServicesExtensions.cs
@@ -29,7 +29,28 @@ namespace ProtoBuf.Grpc.ClientFactory
         /// Registers a provider that can recognize and handle code-first services
         /// </summary>
         public static IHttpClientBuilder AddCodeFirstGrpcClient<T>(this IServiceCollection services,
+            string name, Action<GrpcClientFactoryOptions> configureClient) where T : class
+            => services.AddGrpcClient<T>(name, configureClient).ConfigureCodeFirstGrpcClient<T>();
+
+        /// <summary>
+        /// Registers a provider that can recognize and handle code-first services
+        /// </summary>
+        public static IHttpClientBuilder AddCodeFirstGrpcClient<T>(this IServiceCollection services,
+            string name, Action<IServiceProvider, GrpcClientFactoryOptions> configureClient) where T : class
+            => services.AddGrpcClient<T>(name, configureClient).ConfigureCodeFirstGrpcClient<T>();
+
+        /// <summary>
+        /// Registers a provider that can recognize and handle code-first services
+        /// </summary>
+        public static IHttpClientBuilder AddCodeFirstGrpcClient<T>(this IServiceCollection services,
             Action<GrpcClientFactoryOptions> configureClient) where T : class
+            => services.AddGrpcClient<T>(configureClient).ConfigureCodeFirstGrpcClient<T>();
+
+        /// <summary>
+        /// Registers a provider that can recognize and handle code-first services
+        /// </summary>
+        public static IHttpClientBuilder AddCodeFirstGrpcClient<T>(this IServiceCollection services,
+            Action<IServiceProvider, GrpcClientFactoryOptions> configureClient) where T : class
             => services.AddGrpcClient<T>(configureClient).ConfigureCodeFirstGrpcClient<T>();
 
         /// <summary>


### PR DESCRIPTION
Protobuf-net.Grpc is great, but I have faced with a small problem during migration from `Grpc.Net.ClientFactory` as [ServicesExtensions](https://github.com/almostcake/protobuf-net.Grpc/blob/main/src/protobuf-net.Grpc.ClientFactory/ServicesExtensions.cs) do not implement all the matching methods from [GrpcClientServiceExtensions](https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.Net.ClientFactory/GrpcClientServiceExtensions.cs), especially the ones with `Action<IServiceProvider, GrpcClientFactoryOptions>` which are required for configuration.
This is a small improvement to proxy those methods.