### PR TITLE
Change order for how FileDescriptors are returned in reflection service.

### DIFF
--- a/src/protobuf-net.Grpc.Reflection/ReflectionService.cs
+++ b/src/protobuf-net.Grpc.Reflection/ReflectionService.cs
@@ -153,19 +153,19 @@ namespace ProtoBuf.Grpc.Reflection
             {
                 if (left is null)
                 {
-                    return right is null ? 0 : -1;
+                    return right is null ? 0 : 1;
                 }
                 if (right is null)
                 {
-                    return 1;
+                    return -1;
                 }
                 if (GetTransitiveDependencies(left).Contains(right.Name))
                 {
-                    return 1;
+                    return -1;
                 }
                 if (GetTransitiveDependencies(right).Contains(left.Name))
                 {
-                    return -1;
+                    return 1;
                 }
 
                 return string.Compare(left.Name, right.Name, StringComparison.Ordinal);

--- a/tests/protobuf-net.Grpc.Reflection.Test/ReflectionServiceTests.cs
+++ b/tests/protobuf-net.Grpc.Reflection.Test/ReflectionServiceTests.cs
@@ -74,9 +74,9 @@ namespace protobuf_net.Grpc.Reflection.Test
                 ".ReflectionTest.BclService",
                 new[]
                 {
+                    "ReflectionTest.BclService.proto",
                     "google/protobuf/empty.proto",
-                    "protobuf-net/bcl.proto",
-                    "ReflectionTest.BclService.proto"
+                    "protobuf-net/bcl.proto"
                 }
                 ,
                 new[]


### PR DESCRIPTION
- FileDescriptors should be returned with the service first and then all dependencies after. All dependencies should occur after a FileDescriptor.
- See https://github.com/grpc/grpc-go/issues/2949
  _The Java implementation of the reflection service includes the entire transitive closure for a request file, in toplogical order such that a file's dependencies always appear after the file (so the requested file is first, with all of its dependencies after it)._
  
- Fixes #141 once again 😄 

// cc @mgravell @ChristianWeyer

Example using `grpcurl` with @ChristianWeyer's blazor app (https://github.com/thinktecture/blazor-webassembly-demo)
```
C:\temp>grpcurl localhost:5003 describe
ConfTool.Shared.Contracts.TimeService is a service:
service TimeService {
  rpc Subscribe ( .google.protobuf.Empty ) returns ( stream .ConfTool.Shared.Contracts.TimeResult );
}
ConfTool.Shared.Contracts.ConferencesService is a service:
service ConferencesService {
  rpc AddNewConference ( .ConfTool.Shared.Contracts.ConferenceDetails ) returns ( .ConfTool.Shared.Contracts.ConferenceDetails );
  rpc GetConferenceDetails ( .ConfTool.Shared.Contracts.ConferenceDetailsRequest ) returns ( .ConfTool.Shared.Contracts.ConferenceDetails );
  rpc ListConferences ( .google.protobuf.Empty ) returns ( .ConfTool.Shared.Contracts.IEnumerable_ConferenceOverview );
}
grpc.reflection.v1alpha.ServerReflection is a service:
service ServerReflection {
  rpc ServerReflectionInfo ( stream .grpc.reflection.v1alpha.ServerReflectionRequest ) returns ( stream .grpc.reflection.v1alpha.ServerReflectionResponse );
}
```