### PR TITLE
Correct typo in OperationAttribute

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/OperationAttribute.cs
+++ b/src/protobuf-net.Grpc/Configuration/OperationAttribute.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 namespace ProtoBuf.Grpc.Configuration
 {
     /// <summary>
-    /// Explicitly indicates that a metho represents a gRPC method
+    /// Explicitly indicates that a method represents a gRPC method
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     [ImmutableObject(true)]


### PR DESCRIPTION
Small typo I noticed when working with the library.