### PR TITLE
Bump Grpc versions & add netstandard2.0 target to ClientFactory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,9 +27,9 @@
 
     <ExampleRefs>local</ExampleRefs> <!-- local or nuget-->
     <PBGRPCLibVersion>1.0.147</PBGRPCLibVersion>
-    <GrpcDotNetVersion>2.36.0</GrpcDotNetVersion>
+    <GrpcDotNetVersion>2.37.0</GrpcDotNetVersion>
     <GoogleProtobufVersion>3.15.6</GoogleProtobufVersion>
-    <GrpcVersion>2.36.1</GrpcVersion>
+    <GrpcVersion>2.37.0</GrpcVersion>
 
     <ProtoBufNet2Version>2.4.6</ProtoBufNet2Version>
     <ProtoBufNet3Version>3.0.101</ProtoBufNet3Version>

--- a/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
+++ b/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.ClientFactory</RootNamespace>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
grpc-dotnet added support for netstandard2.0 in ClientFactory as of 2.37.0: https://github.com/grpc/grpc-dotnet/commit/6fd69504c7ad4496a04c77e643e222507fb0846f

I'd love to use the protobuf-net.Grpc equivalent in a .NET Framework project, so it'd be really nice if that could be mirrored here 🙏 