### PR TITLE
Fix an unobserved task exception

### DIFF
--- a/src/protobuf-net.Grpc/Internal/Reshape.cs
+++ b/src/protobuf-net.Grpc/Internal/Reshape.cs
@@ -520,7 +520,10 @@ namespace ProtoBuf.Grpc.Internal
             }
             catch
             {
-                allDone.Cancel();
+                if (!allDone.IsCancellationRequested)
+                {
+                    allDone.Cancel();
+                }
                 throw;
             }
         }

--- a/src/protobuf-net.Grpc/Internal/Reshape.cs
+++ b/src/protobuf-net.Grpc/Internal/Reshape.cs
@@ -522,7 +522,11 @@ namespace ProtoBuf.Grpc.Internal
             {
                 if (!allDone.IsCancellationRequested)
                 {
-                    allDone.Cancel();
+                    try
+                    {
+                        allDone.Cancel();
+                    }
+                    catch { } // calls to "Cancel" can race, ignore the exception if we lose the race
                 }
                 throw;
             }


### PR DESCRIPTION
Addresses an unobserved exception that occurs when an `ObjectDisposedException` is raised after a `CancellationToken` is cancelled by only cancelling if the token has not been previously cancelled. The default `catch` will fire for an `OperationCanceledException` and then attempt to cancel the same `CancellationToken` that was just cancelled.