### PR TITLE
Reflection schema generation support inherited methods and generics

### DIFF
--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -139,7 +139,7 @@ namespace ProtoBuf.Grpc.Reflection
 
         private static MethodInfo[] GetMethodsRecursively(ServiceBinder serviceBinder, Type contractType)
         {
-            var includingInheritedInterfaces = ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(contractType);
+            var includingInheritedInterfaces = ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(serviceBinder, contractType);
 
             var inheritedMethods = includingInheritedInterfaces
                 .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance))

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -105,10 +105,9 @@ namespace ProtoBuf.Grpc.Reflection
 
         private static MethodInfo[] GetMethodsRecursively(ServiceBinder serviceBinder, Type contractType)
         {
-            var includingInheritedInterfaces = ContractOperation.ExpandInterfaces(contractType);
+            var includingInheritedInterfaces = ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(contractType);
 
             var inheritedMethods = includingInheritedInterfaces
-                .Where(cType => serviceBinder.IsServiceContract(cType, out _)) // only the ones marked as contract type
                 .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance))
                 .ToArray();
             

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -105,16 +105,14 @@ namespace ProtoBuf.Grpc.Reflection
 
         private static MethodInfo[] GetMethodsRecursively(ServiceBinder serviceBinder, Type contractType)
         {
-            var methods = contractType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-            var baseContractInterfaces = 
-                contractType.GetInterfaces()
-                .Where(cType => serviceBinder.IsServiceContract(cType, out _)); // only the ones marked as contract type 
+            var includingInheritedInterfaces = ContractOperation.ExpandInterfaces(contractType);
 
-            var inheritedMethods = baseContractInterfaces.SelectMany(cType => GetMethodsRecursively(serviceBinder, cType)).ToArray();
-            if (inheritedMethods.Any())
-                return inheritedMethods.Concat(methods).ToArray();
+            var inheritedMethods = includingInheritedInterfaces
+                .Where(cType => serviceBinder.IsServiceContract(cType, out _)) // only the ones marked as contract type
+                .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+                .ToArray();
             
-            return methods;
+            return inheritedMethods;
         }
     }
 }

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Grpc.Configuration;
 using ProtoBuf.Grpc.Internal;
 using ProtoBuf.Meta;
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace ProtoBuf.Grpc.Reflection
@@ -47,7 +48,8 @@ namespace ProtoBuf.Grpc.Reflection
             {
                 Name = name
             };
-            var ops = contractType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+            
+            var ops = GetMethodsRecursively(contractType);
             foreach (var method in ops)
             {
                 if (method.DeclaringType == typeof(object))
@@ -99,6 +101,17 @@ namespace ProtoBuf.Grpc.Reflection
                 if (type == typeof(TimeSpan)) return typeof(WellKnownTypes.Duration);
                 return type;
             }
+        }
+
+        private static MethodInfo[] GetMethodsRecursively(Type contractType)
+        {
+            var methods = contractType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+            var baseInterfaces = contractType.GetInterfaces();
+            var inheritedMethods = baseInterfaces.SelectMany(iface => GetMethodsRecursively(iface)).ToArray();
+            if (inheritedMethods.Any())
+                return inheritedMethods.Concat(methods).ToArray();
+            
+            return methods;
         }
     }
 }

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -39,15 +39,18 @@ namespace ProtoBuf.Grpc.Configuration
             object?[]? argsBuffer = null;
             Type[] typesBuffer = Array.Empty<Type>();
             if (binderConfiguration == null) binderConfiguration = BinderConfiguration.Default;
-            var serviceContracts = typeof(IGrpcService).IsAssignableFrom(serviceType)
+            var potentialServiceContracts = typeof(IGrpcService).IsAssignableFrom(serviceType)
                 ? new HashSet<Type> {serviceType}
                 : ContractOperation.ExpandInterfaces(serviceType);
 
             bool serviceImplSimplifiedExceptions = serviceType.IsDefined(typeof(SimpleRpcExceptionsAttribute));
-            foreach (var serviceContract in serviceContracts)
+            foreach (var potentialServiceContract in potentialServiceContracts)
             {
-                if (!binderConfiguration.Binder.IsServiceContract(serviceContract, out var serviceName)) continue;
+                if (!binderConfiguration.Binder.IsServiceContract(potentialServiceContract, out var serviceName)) continue;
 
+                // now that we know it is a service contract type for sure
+                var serviceContract = potentialServiceContract;
+                
                 var typesToBeIncludedInMethodsBinding =
                     ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(serviceContract);
 

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -52,7 +52,7 @@ namespace ProtoBuf.Grpc.Configuration
                 var serviceContract = potentialServiceContract;
                 
                 var typesToBeIncludedInMethodsBinding =
-                    ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(serviceContract);
+                    ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(binderConfiguration.Binder, serviceContract);
 
                 // Per service contract, we will collect all the methods of inherited interfaces
                 // and bind them as they were defined in the service contract itself.

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -220,5 +220,28 @@ namespace ProtoBuf.Grpc.Configuration
             }
             return null;
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="typesToSearchIn"></param>
+        /// <param name="serviceName"></param>
+        /// <returns></returns>
+        public bool TryFindInheritedService(Type type, IEnumerable<Type> typesToSearchIn, out string? serviceName)
+        {
+            foreach (var potentialServiceContract in typesToSearchIn)
+            {
+                if (potentialServiceContract != type
+                    && type.IsAssignableFrom(potentialServiceContract)
+                    && IsServiceContract(potentialServiceContract, out serviceName))
+                {
+                    return true;
+                }
+            }
+
+            serviceName = null;
+            return false;
+        }
     }
 }

--- a/src/protobuf-net.Grpc/Configuration/ServiceInheritableAttribute.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceInheritableAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace ProtoBuf.Grpc.Configuration
+{
+    /// <summary>
+    /// Indicates that this interface can be inherited by a gRPC service.
+    /// All methods of this interface will be routed based on inherited service name.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    [ImmutableObject(true)]
+    public sealed class ServiceInheritableAttribute : Attribute
+    {
+    }
+}

--- a/src/protobuf-net.Grpc/Internal/ContractOperation.cs
+++ b/src/protobuf-net.Grpc/Internal/ContractOperation.cs
@@ -363,6 +363,29 @@ namespace ProtoBuf.Grpc.Internal
             if (type.IsInterface) set.Add(type);
             return set;
         }
+        
+        /// <summary>
+        /// Collect all the types to be used for extracting methods for a specific Service Contract
+        /// </summary>
+        /// <param name="serviceContract">Must be a service contract</param>
+        /// <returns>types to be used for extracting methods</returns>
+        internal static ISet<Type> ExpandWithInterfacesMarkedAsServiceInheritable(Type serviceContract)
+        {
+            var set = new HashSet<Type>();
+            
+            // first add the service contract by itself 
+            set.Add(serviceContract); 
+
+            // now add all inherited interfaces which are marked as inheritable
+            foreach (var t in serviceContract.GetInterfaces())
+            {
+                if (t.IsDefined(typeof(ServiceInheritableAttribute)))
+                {
+                    set.Add(t);
+                }
+            }
+            return set;
+        }
     }
 
     internal enum ContextKind

--- a/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
+++ b/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
@@ -156,7 +156,9 @@ service MyInheritedService {
             }
             viaSchema.Sort();
 
-            Assert.Equal(string.Join(Environment.NewLine, viaBinder), string.Join(Environment.NewLine, viaSchema));
+            var routeTableViaBinder = string.Join(Environment.NewLine, viaBinder);
+            var routeTableViaSchame = string.Join(Environment.NewLine, viaSchema);
+            Assert.Equal(routeTableViaBinder, routeTableViaSchame);
 
         }
 
@@ -196,7 +198,7 @@ service MyInheritedService {
             void InheritedSyncEmpty();
         }
         
-        [ServiceInheritable]
+        [ServiceInheritable][Service]
         public interface ISecondLevelInheritable : ISomeInheritableGenericService<MyRequest, MyResponse>, INotAService
         {
             ValueTask<MyResponse> InheritedUnary(MyRequest request, CallContext callContext = default);

--- a/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
+++ b/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
@@ -199,7 +199,7 @@ service MyInheritedService {
             void InheritedSyncEmpty();
         }
         
-        [ServiceInheritable][Service]
+        [ServiceInheritable]
         public interface ISecondLevelInheritable : ISomeInheritableGenericService<MyRequest, MyResponse>, INotAService
         {
             ValueTask<MyResponse> InheritedUnary(MyRequest request, CallContext callContext = default);
@@ -301,11 +301,7 @@ service ConferencesService {
 }
 ", proto, ignoreLineEndingDifferences: true);
         }
-
-        public interface INotAService
-        {
-            ValueTask<MyResponse> SomeMethod1(MyRequest request, CallContext callContext = default);
-        }        
+        
         [Fact]
         public void WhenInterfaceIsNotServiceContract_Throw()
         {

--- a/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
+++ b/tests/protobuf-net.Grpc.Reflection.Test/SchemaGeneration.cs
@@ -324,6 +324,21 @@ service ConferencesService {
             Assert.Throws<ArgumentException>(activation.Invoke);
         }
 
+
+        [Service]
+        [ServiceInheritable]
+        public interface IIServiceWithBothServiceAndServiceInheritableAttributes
+        {
+            void SomeMethod();
+        }
+        [Fact]
+        public void WhenInterfaceHasAttributesServiceAndServiceInheritable_Throw()
+        {
+            var generator = new SchemaGenerator();
+            Action activation = () => generator.GetSchema<IIServiceWithBothServiceAndServiceInheritableAttributes>();
+            Assert.Throws<ArgumentException>(activation.Invoke);
+        }
+
         [Service]
         public interface ISimpleService1
         {

--- a/tests/protobuf-net.Grpc.Test.Integration/ClientProxyTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/ClientProxyTests.cs
@@ -1,0 +1,150 @@
+﻿using Grpc.Core;
+using ProtoBuf;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Configuration;
+using ProtoBuf.Grpc.Server;
+using ProtoBuf.Meta;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using ProtoBuf.Grpc;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable disable
+
+namespace protobuf_net.Grpc.Test.Integration
+{
+    public class ClientProxyTests : IClassFixture<ClientProxyTests.ClientProxyTestsServerFixture>
+    {
+
+        [DataContract]
+        public class MyRequest
+        {
+            [DataMember(Order = 1)]
+            public int Id { get; set; }
+        }
+
+        [DataContract]
+        public class MyResponse
+        {
+            [DataMember(Order = 1)]
+            public string? Value { get; set; }
+        }
+       
+       
+        /// <summary>
+        /// An interface which is not marked with [Service] attribute.
+        /// Its methods' proxy-implementations are expected to throw unsupported exception.
+        /// </summary>
+        public interface INotAService
+        {
+            ValueTask<MyResponse> NotAServiceUnary(MyRequest request, CallContext callContext = default);
+        }
+
+        [ServiceInheritable]
+        public interface ISomeInheritableBaseGenericService<in TGenericRequest, TGenericResult>
+        {
+            ValueTask<TGenericResult> BaseGenericUnary(TGenericRequest request, CallContext callContext = default);
+        }
+        
+        [Service]
+        public interface IMyDerivedService : ISomeInheritableBaseGenericService<MyRequest, MyResponse>, INotAService
+        {
+            ValueTask<MyResponse> Derived(MyRequest request, CallContext callContext = default);
+        }
+
+#pragma warning disable IDE0079 // Remove unnecessary suppression
+#pragma warning disable IDE0051, IDE0052 // "unused" things; they are, but it depends on the TFM
+        private readonly ITestOutputHelper _log;
+        private readonly ClientProxyTestsServerFixture _server;
+        private void Log(string message) => _log?.WriteLine(message);
+#pragma warning restore IDE0051, IDE0052
+#pragma warning restore IDE0079 // Remove unnecessary suppression
+
+        private int Port => _server.Port;
+
+        public ClientProxyTests(ClientProxyTestsServerFixture server, ITestOutputHelper log)
+        {
+            _server = server;
+            _log = log;
+            GrpcClientFactory.AllowUnencryptedHttp2 = true;
+        }
+
+        public class ClientProxyTestsServerFixture : IMyDerivedService, IAsyncDisposable
+        {
+            public int Port { get; } = PortManager.GetNextPort();
+
+            public async ValueTask DisposeAsync()
+            {
+                if (_server != null)
+                    await _server.KillAsync();
+            }
+
+            private readonly Server? _server;
+            public ClientProxyTestsServerFixture()
+            {
+                _server = new Server
+                {
+                    Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }
+                };
+                _server.Services.AddCodeFirst(this);
+                _server.Start();
+            }
+
+            public async ValueTask<MyResponse> NotAServiceUnary(MyRequest request, CallContext callContext = default)
+            {
+                // we expect this won't be called through GRPC
+                return await Task.FromResult(new MyResponse());
+            }
+
+            public async ValueTask<MyResponse> Derived(MyRequest request, CallContext callContext = default)
+            {
+                return await Task.FromResult(new MyResponse());
+            }
+
+            public async ValueTask<MyResponse> BaseGenericUnary(MyRequest request, CallContext callContext = default)
+            {
+                return await Task.FromResult(new MyResponse());
+            }
+        }
+
+
+#if !(NET461 || NET472)
+        [Fact]
+        public async Task ClientProxyTests_WhenCalledToDerivedInterfaceMethod_NoException()
+        {
+            using var http = global::Grpc.Net.Client.GrpcChannel.ForAddress($"http://localhost:{Port}");
+            var client = http.CreateGrpcService<IMyDerivedService>();
+            var obj = await client.Derived(new MyRequest());
+        }
+
+        [Fact]
+        public async Task ClientProxyTests_WhenCalledToBaseInheritableMethod_NoException()
+        {
+            using var http = global::Grpc.Net.Client.GrpcChannel.ForAddress($"http://localhost:{Port}");
+            var client = http.CreateGrpcService<IMyDerivedService>();
+            var obj = await client.BaseGenericUnary(new MyRequest());
+        }
+
+
+        [Fact]
+        public async Task ClientProxyTests_WhenCalledToBaseNonInheritableMethod_ThrowsUnsupportedException()
+        {
+            using var http = global::Grpc.Net.Client.GrpcChannel.ForAddress($"http://localhost:{Port}");
+            var client = http.CreateGrpcService<IMyDerivedService>();
+
+            await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            {
+                // we expect an exception from the client proxy
+                var obj = await client.NotAServiceUnary(new MyRequest());
+            });
+        }
+#endif
+    }        
+
+}

--- a/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
+++ b/tests/protobuf-net.Grpc.Test/ContractOperationTests.cs
@@ -82,6 +82,45 @@ namespace protobuf_net.Grpc.Test
 
             Assert.Empty(expected);
         }
+        
+        
+        [Service]
+        [ServiceInheritable]
+        public interface IIServiceWithBothServiceAndServiceInheritableAttributes
+        {
+            void SomeMethod();
+        }
+    
+        [Fact]
+        public void WhenInterfaceHasAttributesServiceAndServiceInheritable_Throw()
+        {
+            var config = BinderConfiguration.Default;
+            Action activation = () => ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(
+                config.Binder, 
+                typeof(IIServiceWithBothServiceAndServiceInheritableAttributes));
+            Assert.Throws<ArgumentException>(activation.Invoke);
+        }
+        
+        public class ServiceContractClassInheritsServiceAndServiceInheritableAttributes
+        : IIServiceWithBothServiceAndServiceInheritableAttributes, IGrpcService
+        {
+            public void SomeMethod()
+            {
+            }
+        }
+    
+        [Fact]
+        public void WhenServiceContractClassImplementsInterfaceHavingAttributesServiceAndServiceInheritable_Throw()
+        {
+            var config = BinderConfiguration.Default;
+            Action activation = () => ContractOperation.ExpandWithInterfacesMarkedAsServiceInheritable(
+                config.Binder, 
+                typeof(ServiceContractClassInheritsServiceAndServiceInheritableAttributes));
+            Assert.Throws<ArgumentException>(activation.Invoke);
+        }
+
+        
+        
 #pragma warning disable CS0618 // Empty
         [Theory]
         [InlineData(nameof(IAllOptions.Client_AsyncUnary), typeof(HelloRequest), typeof(HelloReply), MethodType.Unary, (int)ContextKind.CallOptions, (int)ResultKind.Grpc, (int)VoidKind.None)]


### PR DESCRIPTION
support extracting methods from base interfaces of the main service-interface being reflected.
Add test to prove it works also with base interfaces using Generics.
Generated schema will include also the methods defined in the base interfaces recursively.