### PR TITLE
Reflection - allow generating multi services with their shared classes defined once.

### DIFF
--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -26,14 +26,26 @@ namespace ProtoBuf.Grpc.Reflection
         /// <summary>
         /// Get the .proto schema associated with a service contract
         /// </summary>
+        /// <typeparam name="TService">The service type to generate schema for.</typeparam>
         /// <remarks>This API is considered experimental and may change slightly</remarks>
         public string GetSchema<TService>()
             => GetSchema(typeof(TService));
 
         /// <summary>
+        /// Get the .proto schema associated with a service contract
+        /// </summary>
+        /// <param name="contractType">The service type to generate schema for.</param>
+        /// <remarks>This API is considered experimental and may change slightly</remarks>
+        public string GetSchema(Type contractType)
+            => GetSchema(new [] {contractType});
+
+        /// <summary>
         /// Get the .proto schema associated with multiple service contracts
         /// </summary>
-        /// <remarks>This API is considered experimental and may change slightly</remarks>
+        /// <param name="contractTypes">Array (or params syntax) of service types to generate schema for.</param>
+        /// <remarks>This API is considered experimental and may change slightly
+        /// All types will be generated into single schema.
+        /// All the shared classes the services use will be generated only once for all of them.</remarks>
         public string GetSchema(params Type[] contractTypes)
         {
             string globalPackage = "";

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -35,7 +35,10 @@ namespace ProtoBuf.Grpc.Reflection
         /// Get the .proto schema associated with a service contract
         /// </summary>
         /// <param name="contractType">The service type to generate schema for.</param>
-        /// <remarks>This API is considered experimental and may change slightly</remarks>
+        /// <remarks>This API is considered experimental and may change slightly.
+        /// ATTENTION! although the 'GetSchema(params Type[] contractTypes)' covers also a case of 'GetSchema(Type contractType)',
+        /// this method need to remain for backward compatibility for client which will get this updated version, without recompilation.
+        /// Thus, this method mustn't be deleted.</remarks>
         public string GetSchema(Type contractType)
             => GetSchema(new [] {contractType});
 

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Grpc.Configuration;
 using ProtoBuf.Grpc.Internal;
 using ProtoBuf.Meta;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace ProtoBuf.Grpc.Reflection
@@ -30,62 +31,80 @@ namespace ProtoBuf.Grpc.Reflection
             => GetSchema(typeof(TService));
 
         /// <summary>
-        /// Get the .proto schema associated with a service contract
+        /// Get the .proto schema associated with multiple service contracts
         /// </summary>
         /// <remarks>This API is considered experimental and may change slightly</remarks>
-        public string GetSchema(Type contractType)
+        public string GetSchema(params Type[] contractTypes)
         {
+            string globalPackage = "";
+            List<Service> services = new List<Service>();  
             var binderConfiguration = BinderConfiguration ?? BinderConfiguration.Default;
             var binder = binderConfiguration.Binder;
-            if (!binder.IsServiceContract(contractType, out var name))
+            foreach (var contractType in contractTypes)
             {
-                throw new ArgumentException($"Type '{contractType.Name}' is not a service contract", nameof(contractType));
+                if (!binder.IsServiceContract(contractType, out var name))
+                {
+                    throw new ArgumentException($"Type '{contractType.Name}' is not a service contract",
+                        nameof(contractTypes));
+                }
+
+                name = ServiceBinder.GetNameParts(name, contractType, out var package);
+                // currently we allow only services from same package, to be output to single proto file
+                if (!string.IsNullOrEmpty(globalPackage)
+                    && package != globalPackage)
+                {
+                    throw new ArgumentException(
+                        $"All services must be of the same package! '{contractType.Name}' is from package '{package}' while previous package: {globalPackage}",
+                        nameof(contractTypes));
+                }
+                globalPackage = package;
+                
+                var service = new Service
+                {
+                    Name = name
+                };
+                var ops = contractType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+                foreach (var method in ops)
+                {
+                    if (method.DeclaringType == typeof(object))
+                    {
+                        /* skip */
+                    }
+                    else if (ContractOperation.TryIdentifySignature(method, binderConfiguration, out var op, null))
+                    {
+                        service.Methods.Add(
+                            new ServiceMethod
+                            {
+                                Name = op.Name,
+                                InputType = ApplySubstitutes(op.From),
+                                OutputType = ApplySubstitutes(op.To),
+                                ClientStreaming = op.MethodType switch
+                                {
+                                    MethodType.ClientStreaming => true,
+                                    MethodType.DuplexStreaming => true,
+                                    _ => false,
+                                },
+                                ServerStreaming = op.MethodType switch
+                                {
+                                    MethodType.ServerStreaming => true,
+                                    MethodType.DuplexStreaming => true,
+                                    _ => false,
+                                },
+                            }
+                        );
+                    }
+                }
+
+                service.Methods.Sort((x, y) => string.Compare(x.Name, y.Name)); // make it predictable
+                services.Add(service);
             }
 
-            name = ServiceBinder.GetNameParts(name, contractType, out var package);
-            var service = new Service
-            {
-                Name = name
-            };
-            var ops = contractType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-            foreach (var method in ops)
-            {
-                if (method.DeclaringType == typeof(object))
-                { /* skip */ }
-                else if (ContractOperation.TryIdentifySignature(method, binderConfiguration, out var op, null))
-                {
-                    service.Methods.Add(
-                        new ServiceMethod
-                        {
-                            Name = op.Name,
-                            InputType = ApplySubstitutes(op.From),
-                            OutputType = ApplySubstitutes(op.To),
-                            ClientStreaming = op.MethodType switch
-                            {
-                                MethodType.ClientStreaming => true,
-                                MethodType.DuplexStreaming => true,
-                                _ => false,
-                            },
-                            ServerStreaming = op.MethodType switch
-                            {
-                                MethodType.ServerStreaming => true,
-                                MethodType.DuplexStreaming => true,
-                                _ => false,
-                            },
-                        }
-                    );
-                }
-            }
-            service.Methods.Sort((x, y) => string.Compare(x.Name, y.Name)); // make it predictable
             var options = new SchemaGenerationOptions
             {
                 Syntax = ProtoSyntax,
-                Package = package,
-                Services =
-                {
-                    service
-                }
+                Package = globalPackage,
             };
+            options.Services.AddRange(services);
 
             var model = binderConfiguration.MarshallerCache.TryGetFactory<ProtoBufMarshallerFactory>()?.Model ?? RuntimeTypeModel.Default;
             return model.GetSchema(options);


### PR DESCRIPTION
allow generating multi services with their shared classes defined once.
Suppose there is a service which gets some params:

Suppose we have following two services:
```
    [Service]
    interface IVehicleRentService
    {
        Task<VehicleRentResponse> RentVehicle(VehicleRentRequest vehicleRentRequest);
    }

    [Service]
    interface IToxedoRentService
    {
        Task<ToxedoRentResponse> RentToxedo(ToxedoRentRequest toxedoRentRequest);
    }

    [ProtoContract]
    public class ToxedoRentRequest
    {
        [ProtoMember(1)]
        public RenterPersonalInfo RenterPersonalInfo { get; set; }
        [ProtoMember(2)]
        public RenterFavorites RenterFavorites { get; set; }
        [ProtoMember(3)]
        public Purpose RentPurpose { get; set; }

        public enum Purpose
        {
            Business,
            Joy,
            Travel,
            // etc
        };
    }
    [ProtoContract]
    public class VehicleRentRequest
    {
        [ProtoMember(1)]
        public RenterPersonalInfo RenterPersonalInfo { get; set; }
        [ProtoMember(2)]
        public RenterFavorites RenterFavorites { get; set; }
        [ProtoMember(3)]
        public VehicleLicense[]  LicenseTypes { get; set; }
        
        public enum VehicleLicense
        {
            Private,
            Motorcycle,
            Track,
            Bus,
            Semitrailer,
        };        
    }    

    [ProtoContract]
    public class RenterFavorites
    {
        public enum PreferredColor
        {
            DontCare,
            Red,
            White,
            // etc
        };
        public enum PreferredStyle
        {
            DontCare,
            Cool,
            Solid,
            // etc
        };

        [ProtoMember(1)]
        public PreferredColor RenterPreferredColor { get; set; }
        [ProtoMember(2)]
        public PreferredStyle RenterPreferredStyle { get; set; }
    }

    internal class RenterPersonalInfo
    {
        [ProtoMember(1)]
        public string Id { get; set; }
        [ProtoMember(2)]
        public string FirstName { get; set; }
        [ProtoMember(3)]
        public string LastName { get; set; }
        [ProtoMember(4)]
        public uint Age { get; set; }
    }
```

Since there are several classes which are resued between the services, it won't be good generating different proto files.
The outcome will be that their code gen will produce duplicated classes, which cannot be reused. 
A client's  developers will need to fill in the inputs of the two services separately, while nothing can be reused.
Hard work and a risk for mistakes.
Better will be if both services schema(s) will finally produce code which can be reused.

This PR lets that happen by producing a single proto file representing several services (currently only same namespace/package is supported) and all the shared classes are defined only once.
That will let the developers **filling the shared information only once** and providing that same data as (reused) input to the different services to be handled separately. 


Added more unit tests to cover this feature.
Added an addition unit test of exception in case schema gets a non service contract interface/class.