### PR TITLE
ServiceBinder may end up being used concurrently; make sure the internal data supports this

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using ProtoBuf.Grpc.Internal;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
-using ProtoBuf.Grpc.Internal;
 
 namespace ProtoBuf.Grpc.Configuration
 {
@@ -19,11 +20,12 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         protected ServiceBinder() { }
 
-        private readonly Dictionary<Type, InterfaceMapping> _map = new Dictionary<Type, InterfaceMapping>();
+        private readonly ConcurrentDictionary<Type, InterfaceMapping> _map = new ConcurrentDictionary<Type, InterfaceMapping>();
         private InterfaceMapping GetMap(Type contractType, Type serviceType)
         {
             if (!_map.TryGetValue(contractType, out var interfaceMapping))
-            {
+            {   // note: it doesn't matter if this ends up getting called more than once
+                // in a race condition - we don't need to block etc (the result will be compatible)
                 interfaceMapping = serviceType.GetInterfaceMap(contractType);
                 _map[contractType] = interfaceMapping;
             }

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -20,14 +20,14 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         protected ServiceBinder() { }
 
-        private readonly ConcurrentDictionary<Type, InterfaceMapping> _map = new ConcurrentDictionary<Type, InterfaceMapping>();
-        private InterfaceMapping GetMap(Type contractType, Type serviceType)
+        private static readonly ConcurrentDictionary<Type, InterfaceMapping> s_map = new ConcurrentDictionary<Type, InterfaceMapping>();
+        private static InterfaceMapping GetMap(Type contractType, Type serviceType)
         {
-            if (!_map.TryGetValue(contractType, out var interfaceMapping))
+            if (!s_map.TryGetValue(contractType, out var interfaceMapping))
             {   // note: it doesn't matter if this ends up getting called more than once
                 // in a race condition - we don't need to block etc (the result will be compatible)
                 interfaceMapping = serviceType.GetInterfaceMap(contractType);
-                _map[contractType] = interfaceMapping;
+                s_map[contractType] = interfaceMapping;
             }
             return interfaceMapping;
         }


### PR DESCRIPTION
fix #202

also makes the interface-map `static`; this is a view on unchanging IL metadata without interpretation - it isn't instance-specific