### PR TITLE
Extra space removed after the url

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="myget" value="https://www.myget.org/F/protobuf-net/api/v3/index.json " />
+    <add key="myget" value="https://www.myget.org/F/protobuf-net/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
It worked earlier when I compiled version 1.0.136 in VS 2019, but now it causes a lot of build errors in VS2022... even that state, too. So probably something was fixed in VS which is not trimming the url anymore.