### PR TITLE
Add blazor hint (when possible)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2019
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.201
+    choco install dotnet-sdk --version 6.0.302
 
 skip_branch_with_pr: true
 skip_tags: true

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## unreleased
+
+- try to improve blazor linker support (i.e. avoid removal of necessary APIs)
+
 ## 1.0.136
 
 - add .NET 5 target

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100",
+    "version": "6.0.302",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/src/protobuf-net.Grpc/Client/GrpcClientFactory.cs
+++ b/src/protobuf-net.Grpc/Client/GrpcClientFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Grpc.Core;
 using ProtoBuf.Grpc.Configuration;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Grpc.Client
@@ -10,6 +11,13 @@ namespace ProtoBuf.Grpc.Client
     /// </summary>
     public static class GrpcClientFactory
     {
+#if NET5_0_OR_GREATER
+        // it is *intended* that this attribute usage will help the linker not remove things that we need
+        // see: https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#dynamicallyaccessedmembers
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        internal static readonly Type ClientBaseType = typeof(ClientBase);
+
         private const string SwitchAllowUnencryptedHttp2 = "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport";
         /// <summary>
         /// Allows HttpClient to use HTTP/2 without TLS

--- a/src/protobuf-net.Grpc/Internal/ProxyEmitter.cs
+++ b/src/protobuf-net.Grpc/Internal/ProxyEmitter.cs
@@ -1,4 +1,5 @@
 ﻿using Grpc.Core;
+using ProtoBuf.Grpc.Client;
 using ProtoBuf.Grpc.Configuration;
 using System;
 using System.Collections.Generic;
@@ -135,7 +136,7 @@ namespace ProtoBuf.Grpc.Internal
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static Func<CallInvoker, TService> EmitFactory<TService>(BinderConfiguration binderConfig)
         {
-            Type baseType = typeof(ClientBase);
+            Type baseType = GrpcClientFactory.ClientBaseType;
 
             var callInvoker = baseType.GetProperty("CallInvoker", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetGetMethod(true);
             if (callInvoker == null || callInvoker.ReturnType != typeof(CallInvoker) || callInvoker.GetParameters().Length != 0)


### PR DESCRIPTION
Relates to #247 - intention is for blazor linker to not remove APIs in `ClientBase` that it doesn't think are used, but: which are