### PR TITLE
Bump minimum protobuf-net version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@
 
     <ProtoBufNet2Version>2.4.6</ProtoBufNet2Version>
     <ProtoBufNet3Version>3.0.101</ProtoBufNet3Version>
+    <ProtoBufNetServiceModelVersion>3.0.101</ProtoBufNetServiceModelVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='VS'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/examples/perf/PerfClient/PerfClient.csproj
+++ b/examples/perf/PerfClient/PerfClient.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="protobuf-net.ServiceModel" Version="$(ProtoBufNetServiceModelVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />

--- a/examples/perf/PerfServer/PerfServer.csproj
+++ b/examples/perf/PerfServer/PerfServer.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="protobuf-net.ServiceModel" Version="$(ProtoBufNetServiceModelVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />

--- a/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
+++ b/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Core.Api" Version="$(GrpcVersion)" />
-    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet2Version)" />
+    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet3Version)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />    
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />

--- a/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
+++ b/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
@@ -21,6 +21,7 @@
     </PackageReference>
     <ProjectReference Include="..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
     <PackageReference Include="Grpc.Core.Api" Version="$(GrpcVersion)" />
+    <PackageReference Include="protobuf-net.ServiceModel" Version="$(ProtoBufNetServiceModelVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472'">

--- a/toys/PlayClient/PlayClient.csproj
+++ b/toys/PlayClient/PlayClient.csproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="protobuf-net.ServiceModel" Version="$(ProtoBufNetServiceModelVersion)" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net461'">

--- a/toys/PlayServer/PlayServer.csproj
+++ b/toys/PlayServer/PlayServer.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="protobuf-net.ServiceModel" Version="$(ProtoBufNetServiceModelVersion)" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\PlayClient\PlayClient.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use protobuf-net 3.x
- Add protobuf-net.ServiceModel in example projects as this functionality is now in a separate package

Reasons for this change:
- Unity only works with .NET Standard 2.0 and protobuf-net version 2.x carries over dependencies from .NET Standard 1.1 such as System.Reflection.Emit 4.3.0 and the like.
- In order to add it to this registry, it needs to meet this requirement: https://github.com/xoofx/UnityNuGet
- I understand that since 2 years have passed since the release of protobuf-net 3.x there is no impediment for this dependency to be on the 3.x branch instead of 2.x.