### PR TITLE
Rev libs and TFMs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,8 @@
     <RepositoryType>git</RepositoryType>
     <Product>protobuf-net.Grpc ($(TargetFramework))</Product>
     <PackageReleaseNotes>https://protobuf-net.github.io/protobuf-net.Grpc/releasenotes#$(VersionPrefix)</PackageReleaseNotes>
-    
+
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <PackageTags>grpc</PackageTags>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
@@ -26,13 +27,8 @@
     <!--<CodeAnalysisRuleset>$(MSBuildThisFileDirectory)Shared.ruleset</CodeAnalysisRuleset>-->
 
     <ExampleRefs>local</ExampleRefs> <!-- local or nuget-->
-    <PBGRPCLibVersion>1.0.167</PBGRPCLibVersion>
-    <GrpcDotNetVersion>2.44.0</GrpcDotNetVersion>
-    <GoogleProtobufVersion>3.19.2</GoogleProtobufVersion>
-    <GrpcVersion>2.44.0</GrpcVersion>
 
-    <ProtoBufNet2Version>2.4.6</ProtoBufNet2Version>
-    <ProtoBufNet3Version>3.0.101</ProtoBufNet3Version>
+    <ProtoBufNet2Version>2.4.8</ProtoBufNet2Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='VS'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -49,8 +45,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,19 +18,19 @@
         <PackageVersion Include="Grpc.AspNetCore" Version="2.51.0" />
         <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.51.0" />
         
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.2" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
         
-        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.3.37" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.119" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
         <PackageVersion Include="System.Reactive" Version="5.0.0" />
-        <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
-        <PackageVersion Include="System.ServiceModel.Primitives" Version="4.8.1" />
-        <PackageVersion Include="xunit" Version="2.4.1" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+        <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
+        <PackageVersion Include="System.ServiceModel.Primitives" Version="4.10.0" />
+        <PackageVersion Include="xunit" Version="2.4.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageVersion Include="TaskBuilder.fs" Version="2.1.0" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,36 @@
+<Project>
+    <ItemGroup>
+        <PackageVersion Include="protobuf-net" Version="3.1.33" />
+        <PackageVersion Include="protobuf-net.Core" Version="3.1.33" />
+        <PackageVersion Include="protobuf-net.Grpc" Version="1.0.179" />
+        <PackageVersion Include="protobuf-net.Reflection" Version="3.1.33" />
+        <PackageVersion Include="protobuf-net.MSBuild" Version="3.1.33" />
+        
+        <PackageVersion Include="Google.Protobuf" Version="3.21.12" />
+        
+        <PackageVersion Include="Grpc" Version="2.46.6" />
+        <PackageVersion Include="Grpc.Core" Version="2.46.6" />
+        
+        <PackageVersion Include="Grpc.Tools" Version="2.51.0" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.51.0" />
+        <PackageVersion Include="Grpc.Core.Api" Version="2.51.0" />
+        <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.51.0" />
+        <PackageVersion Include="Grpc.AspNetCore" Version="2.51.0" />
+        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.51.0" />
+        
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+        
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.3.37" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+        <PackageVersion Include="System.Reactive" Version="5.0.0" />
+        <PackageVersion Include="System.Threading.Channels" Version="5.0.0" />
+        <PackageVersion Include="System.ServiceModel.Primitives" Version="4.8.1" />
+        <PackageVersion Include="xunit" Version="2.4.1" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+        <PackageVersion Include="TaskBuilder.fs" Version="2.1.0" />
+    </ItemGroup>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2019
 
 install:
 - cmd: >-
-    choco install dotnet-sdk --version 6.0.302
+    choco install dotnet-sdk --version 7.0.102
 
 skip_branch_with_pr: true
 skip_tags: true

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -43,7 +43,7 @@ reports problems at build-time.
 ### 1: define your data contracts and service contracts
 
 Your service and data contracts can be placed directly in the client/server (see later), or can be in a separate class library. If you use
-a separate library, make sure you target `netcoreapp3.0` or above.
+a separate library, make sure you target `net6.0` or above.
 
 As for what they look like: think "WCF". Data contracts are classes marked with either `[ProtoContract]` or `[DataContract]`, with individual members
 annotated with either `[ProtoMember]` or `[DataMember]`. The `[Proto*]` options are protobuf-net specific and offer fine-grained
@@ -200,7 +200,7 @@ introduction of `.google.protobuf.Timestamp`). It is recommended to use `DataFor
 
 ### 2: implement the server
 
-1. Create an ASP.NET Core Web Application targeting `netcoreapp3.0`, and add a package references to [`protobuf-net.Grpc.AspNetCore`](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore)
+1. Create an ASP.NET Core Web Application targeting `net7.0`, and add a package references to [`protobuf-net.Grpc.AspNetCore`](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore)
 (and a project/package reference to your data/service contracts if necessary). Note that the gRPC tooling can run alongside other services/sites that your ASP.NET application is providing.
 2. in `CreateHostBuilder`, make sure you are using `WebHost`, and enable listening on `HttpProtocols.Http2`; see [`Program.cs`](https://github.com/protobuf-net/protobuf-net.Grpc/blob/main/examples/pb-net-grpc/Server_CS/Program.cs)
 3. in `ConfigureServices`, call `services.AddCodeFirstGrpc()`; see [`Startup.cs`](https://github.com/protobuf-net/protobuf-net.Grpc/blob/main/examples/pb-net-grpc/Server_CS/Startup.cs)
@@ -262,7 +262,7 @@ Now listening on: http://localhost:10042
 
 ### 2: implement the client
 
-OK, we have a working server; now let's write a client. This is much easier, in fact. Let's create a .NET Core console application targeting `netcoreapp3.0`,
+OK, we have a working server; now let's write a client. This is much easier, in fact. Let's create a .NET console application targeting `net7.0`,
 and add a package reference to [`protobuf-net.Grpc`](https://www.nuget.org/packages/protobuf-net.Grpc). Note that by default, `HttpClient` only wants to talk HTTP/2 over TLS, so we first
 need to twist it's arm a little; then we can very easily create a client to our services at our base address; let's start by doing some maths:
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+- update library references
+- drop net461 (moving to net462 as lower bound); drop netcoreapp3.1 and net5.0 (moving to net6.0 as lower bound)
+
 ## 1.0.177
 
 - support sub`[SubService]` (imports one interface inside another top-level service interface) (#206 via meirkr; also protobuf-net #859)

--- a/examples/dotnet-grpc/DN_Client/DN_Client.csproj
+++ b/examples/dotnet-grpc/DN_Client/DN_Client.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\grpc\Shared\Shared.csproj" />
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
 </Project>

--- a/examples/dotnet-grpc/DN_Server/DN_Server.csproj
+++ b/examples/dotnet-grpc/DN_Server/DN_Server.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.AspNetCore.Server" />
     <ProjectReference Include="..\..\grpc\Shared\Shared.csproj" />
   </ItemGroup>
 

--- a/examples/grpc/Client/Client.csproj
+++ b/examples/grpc/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/grpc/Server/Server.csproj
+++ b/examples/grpc/Server/Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/grpc/Shared/Shared.csproj
+++ b/examples/grpc/Shared/Shared.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
-    <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcVersion)">
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc" />
+    <PackageReference Include="Grpc.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/examples/pb-net-grpc/Client_CS/Client_CS.csproj
+++ b/examples/pb-net-grpc/Client_CS/Client_CS.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" />
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
     <ProjectReference Include="..\Shared_CS\Shared_CS.csproj" />
   </ItemGroup>
 

--- a/examples/pb-net-grpc/Client_FS/Client_FS.fsproj
+++ b/examples/pb-net-grpc/Client_FS/Client_FS.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <LangVersion>4.7</LangVersion>
   </PropertyGroup>
@@ -13,15 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" />
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
     <ProjectReference Include="..\Shared_FS\Shared_FS.fsproj" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
+    <PackageReference Include="TaskBuilder.fs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
-  </ItemGroup>
-
 </Project>

--- a/examples/pb-net-grpc/Client_VB/Client_VB.vbproj
+++ b/examples/pb-net-grpc/Client_VB/Client_VB.vbproj
@@ -4,13 +4,13 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
     <RootNamespace>Client_VB</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" />
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
     <ProjectReference Include="..\Shared_VB\Shared_VB.vbproj" />
   </ItemGroup>
 </Project>

--- a/examples/pb-net-grpc/Server_CS/Server_CS.csproj
+++ b/examples/pb-net-grpc/Server_CS/Server_CS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>Server_CS</RootNamespace>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc.AspNetCore.Reflection\protobuf-net.Grpc.AspNetCore.Reflection.csproj" />
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" />
     
     <ProjectReference Include="..\Shared_CS\Shared_CS.csproj" />
   </ItemGroup>

--- a/examples/pb-net-grpc/Server_FS/Server_FS.fsproj
+++ b/examples/pb-net-grpc/Server_FS/Server_FS.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <LangVersion>4.7</LangVersion>
   </PropertyGroup>
@@ -15,14 +15,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Shared_FS\Shared_FS.fsproj" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
+    <PackageReference Include="TaskBuilder.fs" />
 
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
-  </ItemGroup>
-
 </Project>

--- a/examples/pb-net-grpc/Server_VB/Server_VB.vbproj
+++ b/examples/pb-net-grpc/Server_VB/Server_VB.vbproj
@@ -4,13 +4,13 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>Server_VB</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc.AspNetCore" />
     
     <ProjectReference Include="..\Shared_VB\Shared_VB.vbproj" />
   </ItemGroup>

--- a/examples/pb-net-grpc/Shared_CS/Shared_CS.csproj
+++ b/examples/pb-net-grpc/Shared_CS/Shared_CS.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
 
     <ProjectReference Condition="'$(ExampleRefs)'=='local'" Include="..\..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Condition="'$(ExampleRefs)'=='nuget'" Include="protobuf-net.Grpc" />
   </ItemGroup>
 
 </Project>

--- a/examples/pb-net-grpc/Shared_FS/Shared_FS.fsproj
+++ b/examples/pb-net-grpc/Shared_FS/Shared_FS.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <LangVersion>4.7</LangVersion>
   </PropertyGroup>
@@ -12,11 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
-  </ItemGroup>
-
 </Project>

--- a/examples/pb-net-grpc/Shared_VB/Shared_VB.vbproj
+++ b/examples/pb-net-grpc/Shared_VB/Shared_VB.vbproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <RootNamespace>Shared_VB</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
   </ItemGroup>
 </Project>

--- a/examples/pb-net/JustProtos/JustProtos.csproj
+++ b/examples/pb-net/JustProtos/JustProtos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net.MSBuild" Version="$(ProtoBufNet3Version)" />
+    <PackageReference Include="protobuf-net.MSBuild" />
   </ItemGroup>
 
 </Project>

--- a/examples/perf/PerfClient/PerfClient.csproj
+++ b/examples/perf/PerfClient/PerfClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -10,13 +10,13 @@
     <None Remove="PerfTest.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
-    <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcVersion)">
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc" />
+    <PackageReference Include="Grpc.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />

--- a/examples/perf/PerfServer/PerfServer.csproj
+++ b/examples/perf/PerfServer/PerfServer.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <None Remove="PerfTest.proto" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="$(GrpcDotNetVersion)" />
-    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
-    <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
-    <PackageReference Include="Grpc.Tools" Version="$(GrpcVersion)">
+    <PackageReference Include="Grpc.AspNetCore.Server" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc" />
+    <PackageReference Include="Grpc.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTicker.Shared/TraderSys.FullStockTicker.Shared.csproj
+++ b/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTicker.Shared/TraderSys.FullStockTicker.Shared.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet3Version)" />
-    <PackageReference Include="protobuf-net.Grpc" Version="$(PBGRPCLibVersion)" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="protobuf-net" />
+    <PackageReference Include="protobuf-net.Grpc" />
   </ItemGroup>
 
 </Project>

--- a/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTickerClientApp/TraderSys.FullStockTickerClientApp.csproj
+++ b/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTickerClientApp/TraderSys.FullStockTickerClientApp.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -13,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="$(GrpcDotNetVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTickerServer/TraderSys.FullStockTickerServer.csproj
+++ b/examples/wcf-port/FullStockTicker/src/TraderSys.FullStockTickerServer/TraderSys.FullStockTickerServer.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer.ClientConsole/TraderSys.SimpleStockTickerServer.ClientConsole.csproj
+++ b/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer.ClientConsole/TraderSys.SimpleStockTickerServer.ClientConsole.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer.Shared/TraderSys.SimpleStockTickerServer.Shared.csproj
+++ b/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer.Shared/TraderSys.SimpleStockTickerServer.Shared.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet3Version)" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="protobuf-net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer/TraderSys.SimpleStockTickerServer.csproj
+++ b/examples/wcf-port/SimpleStockTicker/src/TraderSys.SimpleStockTickerServer/TraderSys.SimpleStockTickerServer.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/TraderSys/src/TraderSys.Portfolios.ClientConsole/TraderSys.Portfolios.ClientConsole.csproj
+++ b/examples/wcf-port/TraderSys/src/TraderSys.Portfolios.ClientConsole/TraderSys.Portfolios.ClientConsole.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/wcf-port/TraderSys/src/TraderSys.Portfolios.Shared/TraderSys.Portfolios.Shared.csproj
+++ b/examples/wcf-port/TraderSys/src/TraderSys.Portfolios.Shared/TraderSys.Portfolios.Shared.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/examples/wcf-port/TraderSys/src/TraderSys.Portfolios/TraderSys.Portfolios.csproj
+++ b/examples/wcf-port/TraderSys/src/TraderSys.Portfolios/TraderSys.Portfolios.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcDotNetVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.302",
+    "version": "7.0.102",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="myget" value="https://www.myget.org/F/protobuf-net/api/v3/index.json" />
+    <!--<add key="myget" value="https://www.myget.org/F/protobuf-net/api/v3/index.json" />-->
   </packageSources>
 </configuration>

--- a/protobuf-net.Grpc.sln
+++ b/protobuf-net.Grpc.sln
@@ -28,7 +28,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{8D5FDB
 		appveyor.yml = appveyor.yml
 		Directory.build.props = Directory.build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
+		nuget.config = nuget.config
 		readme.md = readme.md
 		version.json = version.json
 	EndProjectSection

--- a/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server.Reflection</RootNamespace>
   </PropertyGroup>
 

--- a/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server.Reflection</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\protobuf-net.Grpc.Reflection\protobuf-net.Grpc.Reflection.csproj" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.AspNetCore.Server" />
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server</RootNamespace>
   </PropertyGroup>
 

--- a/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.AspNetCore.Server" />
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
+++ b/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
     <ProjectReference Include="..\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
   </ItemGroup>
 

--- a/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
+++ b/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="$(GrpcVersion)" />
+    <PackageReference Include="Grpc.Core" />
     <ProjectReference Include="..\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
+++ b/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
+++ b/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
         <RootNamespace>ProtoBuf.Grpc.Reflection</RootNamespace>
     </PropertyGroup>
 

--- a/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
+++ b/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
         <RootNamespace>ProtoBuf.Grpc.Reflection</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
         <!-- note this uses v3 features that are not back-ported to v2 -->
-        <PackageReference Include="protobuf-net.Reflection" Version="$(ProtoBufNet3Version)" />
-        <PackageReference Include="protobuf-net" Version="$(ProtoBufNet3Version)" />
-        <PackageReference Include="protobuf-net.Core" Version="$(ProtoBufNet3Version)" />
+        <PackageReference Include="protobuf-net.Reflection" />
+        <PackageReference Include="protobuf-net" />
+        <PackageReference Include="protobuf-net.Core" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protobuf-net.Grpc/Configuration/GoogleProtobufMarshallerFactory.cs
+++ b/src/protobuf-net.Grpc/Configuration/GoogleProtobufMarshallerFactory.cs
@@ -23,9 +23,9 @@ namespace ProtoBuf.Grpc.Configuration
             _knownTypes[type] = created;
             return created is not null;
         }
-        static readonly MethodInfo s_Create = typeof(GoogleProtobufMarshallerFactory).GetMethod(nameof(AutoDetectProtobufMarshaller), BindingFlags.Static | BindingFlags.NonPublic);
+        static readonly MethodInfo s_Create = typeof(GoogleProtobufMarshallerFactory).GetMethod(nameof(AutoDetectProtobufMarshaller), BindingFlags.Static | BindingFlags.NonPublic)!;
 
-        static ConcurrentDictionary<Type, object?> s_KnownTypes = new();
+        static readonly ConcurrentDictionary<Type, object?> s_KnownTypes = new();
         protected internal override Marshaller<T> CreateMarshaller<T>()
         {
             if (_knownTypes.TryGetValue(typeof(T), out var existing))
@@ -37,7 +37,7 @@ namespace ProtoBuf.Grpc.Configuration
             return created!;
         }
 
-        private static ConcurrentDictionary<Type, object?> _knownTypes = new ConcurrentDictionary<Type, object?>();
+        private static readonly ConcurrentDictionary<Type, object?> _knownTypes = new ConcurrentDictionary<Type, object?>();
 
         // attempt to auto-detect the patterns exposed by Google.Protobuf types;
         // this is (by necessity) reflection-based and imperfect
@@ -64,16 +64,16 @@ context.Complete();
 parser.ParseFrom(context.PayloadAsReadOnlySequence()
 */
                         var context = Expression.Parameter(typeof(global::Grpc.Core.DeserializationContext), "context");
-                        var parseFrom = parser.PropertyType.GetMethod("ParseFrom", new Type[] { typeof(ReadOnlySequence<byte>) });
+                        var parseFrom = parser.PropertyType.GetMethod("ParseFrom", new Type[] { typeof(ReadOnlySequence<byte>) })!;
                         Expression body = Expression.Call(Expression.Constant(parser.GetValue(null), parser.PropertyType),
                             parseFrom, Expression.Call(context, nameof(DeserializationContext.PayloadAsReadOnlySequence), Type.EmptyTypes));
                         deserializer = Expression.Lambda<Func<DeserializationContext, T>>(body, context).Compile();
 
                         var message = Expression.Parameter(typeof(T), "message");
                         context = Expression.Parameter(typeof(global::Grpc.Core.SerializationContext), "context");
-                        var setPayloadLength = typeof(global::Grpc.Core.SerializationContext).GetMethod(nameof(global::Grpc.Core.SerializationContext.SetPayloadLength), new Type[] { typeof(int) });
-                        var calculateSize = iMessage.GetMethod("CalculateSize", Type.EmptyTypes);
-                        var writeTo = me.GetMethod("WriteTo", new Type[] { iMessage, typeof(IBufferWriter<byte>) });
+                        var setPayloadLength = typeof(global::Grpc.Core.SerializationContext).GetMethod(nameof(global::Grpc.Core.SerializationContext.SetPayloadLength), new Type[] { typeof(int) })!;
+                        var calculateSize = iMessage.GetMethod("CalculateSize", Type.EmptyTypes)!;
+                        var writeTo = me.GetMethod("WriteTo", new Type[] { iMessage, typeof(IBufferWriter<byte>) })!;
                         body = Expression.Block(
                             Expression.Call(context, setPayloadLength, Expression.Call(message, calculateSize)),
                             Expression.Call(writeTo, message, Expression.Call(context, "GetBufferWriter", Type.EmptyTypes)),
@@ -92,16 +92,16 @@ parser.ParseFrom(context.PayloadAsNewBuffer());
 */
 
                         var context = Expression.Parameter(typeof(global::Grpc.Core.DeserializationContext), "context");
-                        var parseFrom = parser.PropertyType.GetMethod("ParseFrom", new Type[] { typeof(byte[]) });
+                        var parseFrom = parser.PropertyType.GetMethod("ParseFrom", new Type[] { typeof(byte[]) })!;
                         Expression body = Expression.Call(Expression.Constant(parser.GetValue(null), parser.PropertyType),
                             parseFrom, Expression.Call(context, nameof(DeserializationContext.PayloadAsNewBuffer), Type.EmptyTypes));
                         deserializer = Expression.Lambda<Func<DeserializationContext, T>>(body, context).Compile();
 
                         var message = Expression.Parameter(typeof(T), "message");
                         context = Expression.Parameter(typeof(global::Grpc.Core.SerializationContext), "context");
-                        var toByteArray = me.GetMethod("ToByteArray", new Type[] { iMessage });
+                        var toByteArray = me.GetMethod("ToByteArray", new Type[] { iMessage })!;
                         var complete = typeof(global::Grpc.Core.SerializationContext).GetMethod(
-                            nameof(global::Grpc.Core.SerializationContext.Complete), new Type[] { typeof(byte[]) });
+                            nameof(global::Grpc.Core.SerializationContext.Complete), new Type[] { typeof(byte[]) })!;
                         body = Expression.Call(context, complete, Expression.Call(toByteArray, message));
                         serializer = Expression.Lambda<Action<T, global::Grpc.Core.SerializationContext>>(body, message, context).Compile();
                     }

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -267,6 +267,7 @@ namespace ProtoBuf.Grpc.Configuration
         void IBindContext.LogWarning(string message, object?[]? args) => OnWarn(message, args);
         void IBindContext.LogError(string message, object?[]? args) => OnError(message, args);
 
+        /// <summary>
         /// Describes the relationship between a service contract and a service definition
         /// </summary>
         protected internal sealed class ServiceBindContext

--- a/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
+++ b/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc</RootNamespace>
     <DefineConstants>$(DefineConstants);PLAT_NO_CHANNEL_READALLASYNC</DefineConstants>
   </PropertyGroup>
@@ -9,7 +9,7 @@
     <PackageReference Include="Grpc.Core.Api" />
     <PackageReference Include="protobuf-net" VersionOverride="$(ProtoBufNet2Version)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>

--- a/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
+++ b/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc</RootNamespace>
     <DefineConstants>$(DefineConstants);PLAT_NO_CHANNEL_READALLASYNC</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcVersion)" />
-    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet2Version)" />
+    <PackageReference Include="Grpc.Core.Api" />
+    <PackageReference Include="protobuf-net" VersionOverride="$(ProtoBufNet2Version)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 </Project>

--- a/tests/protobuf-net.Grpc.Reflection.Test/protobuf-net.Grpc.Reflection.Test.csproj
+++ b/tests/protobuf-net.Grpc.Reflection.Test/protobuf-net.Grpc.Reflection.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net461;net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Reflection.Test</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/protobuf-net.Grpc.Reflection.Test/protobuf-net.Grpc.Reflection.Test.csproj
+++ b/tests/protobuf-net.Grpc.Reflection.Test/protobuf-net.Grpc.Reflection.Test.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Reflection.Test</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/protobuf-net.Grpc.Test.Integration/ClientProxyTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/ClientProxyTests.cs
@@ -114,7 +114,7 @@ namespace protobuf_net.Grpc.Test.Integration
         }
 
 
-#if !(NET461 || NET472)
+#if !(NET462 || NET472)
         [Fact]
         public async Task ClientProxyTests_WhenCalledToDerivedInterfaceMethod_NoException()
         {

--- a/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/GrpcServiceTests.cs
@@ -1,4 +1,4 @@
-#if !(NET461 || NET472)
+#if !(NET462 || NET472)
 using Grpc.Core;
 using ProtoBuf.Grpc.Server;
 using System;

--- a/tests/protobuf-net.Grpc.Test.Integration/Issues/Issue100.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/Issues/Issue100.cs
@@ -130,7 +130,7 @@ As sub-object :
             }
         }
 
-#if !(NET461 || NET472)
+#if !(NET462 || NET472)
         [Fact]
         public async Task Issue100_ManagedClient()
         {

--- a/tests/protobuf-net.Grpc.Test.Integration/Issues/Issue75_Exceptions.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/Issues/Issue75_Exceptions.cs
@@ -178,7 +178,7 @@ namespace protobuf_net.Grpc.Test.Integration.Issues
             }
         }
 
-#if !(NET461 || NET472)
+#if !(NET462 || NET472)
         [Fact]
         public async Task ManagedClient_Vanilla_Fault()
         {

--- a/tests/protobuf-net.Grpc.Test.Integration/PortManager.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/PortManager.cs
@@ -12,9 +12,9 @@ namespace protobuf_net.Grpc.Test.Integration
             // we have 1024 to 65535 to play with;
             // allow 1000 per TFM, half for down-level,
             // half for up-level
-#if NETCOREAPP3_1
+#if NET6_0
             s_Port = 10000;
-#elif NET5_0
+#elif NET7_0_OR_GREATER
             s_Port = 11000;
 #elif NET472
             s_Port = 12000;

--- a/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
@@ -398,7 +398,7 @@ namespace protobuf_net.Grpc.Test.Integration
         }
     }
 
-#if !(NET461 || NET472)
+#if !(NET462 || NET472)
     public class ManagedStreamTests : StreamTests
     {
         public override bool IsManagedClient => true;

--- a/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
+++ b/tests/protobuf-net.Grpc.Test.Integration/protobuf-net.Grpc.Test.Integration.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Test.Integration</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Reactive" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/protobuf-net.Grpc.Test.IntegrationUpLevel/protobuf-net.Grpc.Test.IntegrationUpLevel.csproj
+++ b/tests/protobuf-net.Grpc.Test.IntegrationUpLevel/protobuf-net.Grpc.Test.IntegrationUpLevel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Test.Integration</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="protobuf-net" Version="$(ProtoBufNet3Version)" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="protobuf-net" />
+    <PackageReference Include="System.Reactive" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.AspNetCore\protobuf-net.Grpc.AspNetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/protobuf-net.Grpc.Test/TestBindings.cs
+++ b/tests/protobuf-net.Grpc.Test/TestBindings.cs
@@ -80,7 +80,7 @@ namespace protobuf_net.Grpc.Test
 
                 T IAsyncStreamReader<T>.Current => default!;
 
-                WriteOptions IAsyncStreamWriter<T>.WriteOptions { get; set; } = WriteOptions.Default;
+                WriteOptions? IAsyncStreamWriter<T>.WriteOptions { get; set; } = WriteOptions.Default;
 
                 private NulStream() { }
 

--- a/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
+++ b/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net461;net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Test</RootNamespace>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1822;CS8981</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'net472'">
     <DefineConstants>$(DefineConstants);CLIENT_FACTORY</DefineConstants>
   </PropertyGroup>
   
@@ -23,7 +23,7 @@
     <PackageReference Include="Grpc.Core.Api" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'net472'">
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.ClientFactory\protobuf-net.Grpc.ClientFactory.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>

--- a/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
+++ b/tests/protobuf-net.Grpc.Test/protobuf-net.Grpc.Test.csproj
@@ -2,30 +2,30 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>net461;net472;netcoreapp5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>protobuf_net.Grpc.Test</RootNamespace>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1822</NoWarn>
+    <NoWarn>$(NoWarn);CA1822;CS8981</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472'">
     <DefineConstants>$(DefineConstants);CLIENT_FACTORY</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <ProjectReference Include="..\..\src\protobuf-net.Grpc\protobuf-net.Grpc.csproj" />
-    <PackageReference Include="Grpc.Core.Api" Version="$(GrpcVersion)" />
+    <PackageReference Include="Grpc.Core.Api" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net461' and '$(TargetFramework)' != 'net472'">
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.ClientFactory\protobuf-net.Grpc.ClientFactory.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/toys/PlayClient/PlayClient.csproj
+++ b/toys/PlayClient/PlayClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net461'">
     <DefineConstants>$(DefineConstants);HTTPCLIENT</DefineConstants>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-    <PackageReference Include="Grpc.Net.Client" Version="$(GrpcDotNetVersion)" />
+    <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 
 </Project>

--- a/toys/PlayClient/PlayClient.csproj
+++ b/toys/PlayClient/PlayClient.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net461'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net462'">
     <DefineConstants>$(DefineConstants);HTTPCLIENT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\protobuf-net.Grpc.Native\protobuf-net.Grpc.Native.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
 

--- a/toys/PlayServer/PlayServer.csproj
+++ b/toys/PlayServer/PlayServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/toys/PlayServer/PlayServer.csproj
+++ b/toys/PlayServer/PlayServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- revs packages
- switches to central package version management, for simplicity
- drops netcoreapp3.1, net5.0 and net461 (adds net462 as baseline - due to 7.0 compatibility statement)
- note that netcoreapp3.1, net5.0 can still use the core lib via netstandard2.1; the aspnet bits need net6.0 (this last could potentially be relaxed a little if needed)