### PR TITLE
add support for IAsyncDisposable

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## unreleased
+
+- improve handling of `IAsyncDisposable`
+
 ## 1.1.1
 
 - update library references

--- a/tests/protobuf-net.Grpc.Test/DisposeTests.cs
+++ b/tests/protobuf-net.Grpc.Test/DisposeTests.cs
@@ -1,0 +1,56 @@
+﻿using Grpc.Core;
+using ProtoBuf.Grpc.Client;
+using ProtoBuf.Grpc.Configuration;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test
+{
+    public class DisposeTests
+    {
+        [Service]
+        public interface IDisposableService : IDisposable, IAsyncDisposable
+        {}
+
+        [Fact]
+        public void DisposeWorks()
+        {
+            using var client = DummyChannel.Instance.CreateGrpcService<IDisposableService>();
+        }
+
+        [Fact]
+        public async Task DisposeAsyncWorks()
+        {
+            await using var client = DummyChannel.Instance.CreateGrpcService<IDisposableService>();
+        }
+    }
+
+    internal sealed class DummyChannel : ChannelBase
+    {
+        public static DummyChannel Instance { get; } = new();
+        private DummyChannel() : base("") { }
+        public override CallInvoker CreateCallInvoker() => DummyCallInvoker.Instance;
+
+        private sealed class DummyCallInvoker : CallInvoker
+        {
+            public static DummyCallInvoker Instance { get; } = new();
+            private DummyCallInvoker() { }
+
+            public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options)
+                => throw new NotSupportedException();
+
+            public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options)
+                => throw new NotSupportedException();
+
+            public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
+                => throw new NotSupportedException();
+
+            public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
+                => throw new NotSupportedException();
+
+            public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
+                => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
1.1.1 added support for `IDisposable`, i.e. so a generated proxy emits a no-op `Dispose`; here we add `IAsyncDisposable` via a default `ValueTask` result

- add support for `IAsyncDisposable`
- add test for `IDisposable` and `IAsyncDisposable`