### PR TITLE
Improve error message when binding methods

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.Default.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.Default.cs
@@ -77,7 +77,7 @@ namespace ProtoBuf.Grpc.Configuration
             }
             catch (Exception ex)
             {
-                OnError(ex.Message);
+                OnError("When binding method \"{0}\". Message: {1}", [method.Name, ex.Message]);
                 return false;
             }
         }


### PR DESCRIPTION
I am converting some WCF services to GRPC using this (awesome) package. However sometimes there are methods with overloads in the service class. This throws an "An item with the same key has already been added", though the message did not mention the name of the method it was trying to bind. 