### PR TITLE
Stream: add memory performance profiler test rig

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,7 +2,11 @@
 
 ## unreleased
 
-## 1.2.0
+## 1.2.2
+
+- fix missing memory recycling in `Stream` scenario
+
+## 1.2.1
 
 - support `[Value]Task<Stream>` as a return value, rewriting via [`stream BytesValue`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/wrappers.proto) - first
   step in [#340](https://github.com/protobuf-net/protobuf-net.Grpc/issues/340)

--- a/src/protobuf-net.Grpc/Internal/Reshape.ByteStream.cs
+++ b/src/protobuf-net.Grpc/Internal/Reshape.ByteStream.cs
@@ -105,6 +105,7 @@ partial class Reshape
                     var chunk = source.Current;
                     var result = await destination.WriteAsync(chunk.Memory, cancellationToken).ConfigureAwait(false);
                     actualLength += chunk.Length;
+                    chunk.Recycle();
 
                     if (result.IsCanceled)
                     {

--- a/toys/PlayClient/MyContracts.cs
+++ b/toys/PlayClient/MyContracts.cs
@@ -1,7 +1,8 @@
-﻿using Grpc.Core;
+﻿using ProtoBuf;
 using ProtoBuf.Grpc;
 using ProtoBuf.Grpc.Configuration;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Serialization;
 using System.ServiceModel;
 using System.Threading.Tasks;
@@ -60,5 +61,17 @@ namespace Shared_CS
     public interface IBidiStreamingService
     {
         IAsyncEnumerable<BidiStreamingResponse> TestAsync(IAsyncEnumerable<BidiStreamingRequest> request, CallContext options);
+
+        ValueTask<Stream> TestStreamAsync(TestStreamRequest request, CallContext options = default);
+    }
+
+    [ProtoContract]
+    public class TestStreamRequest
+    {
+        [ProtoMember(1)]
+        public int Seed { get; set; }
+
+        [ProtoMember(2)]
+        public long Length { get; set; }
     }
 }


### PR DESCRIPTION
importantly, found a missing `Recycle()` call; fixed