### PR TITLE
Add SchemaGenerationOptions overwrite to SchemaGenerator.

### DIFF
--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -17,7 +17,15 @@ namespace ProtoBuf.Grpc.Reflection
         /// <summary>
         /// Gets or sets the syntax version
         /// </summary>
-        public ProtoSyntax ProtoSyntax { get; set; } = ProtoSyntax.Proto3;
+        public ProtoSyntax ProtoSyntax { get => Options.Syntax; set => Options.Syntax = value; }
+
+        /// <summary>
+        /// Gets or sets the options for the generation of the schema.
+        /// </summary>
+        public SchemaGenerationOptions Options { get; set; } = new SchemaGenerationOptions
+        {
+            Syntax = ProtoSyntax.Proto3
+        };
 
         /// <summary>
         /// Gets or sets the binder configuration (the default configuration is used if omitted)
@@ -118,8 +126,10 @@ namespace ProtoBuf.Grpc.Reflection
 
             var options = new SchemaGenerationOptions
             {
-                Syntax = ProtoSyntax,
+                Syntax = Options.Syntax,
                 Package = globalPackage,
+                Flags = Options.Flags,
+                Origin = Options.Origin,
             };
             options.Services.AddRange(services);
 

--- a/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
+++ b/src/protobuf-net.Grpc.Reflection/SchemaGenerator.cs
@@ -20,9 +20,13 @@ namespace ProtoBuf.Grpc.Reflection
         public ProtoSyntax ProtoSyntax { get => Options.Syntax; set => Options.Syntax = value; }
 
         /// <summary>
-        /// Gets or sets the options for the generation of the schema.
+        /// Gets the options used as a template for schema generation; configure in-place.
         /// </summary>
-        public SchemaGenerationOptions Options { get; set; } = new SchemaGenerationOptions
+        /// <remarks>
+        /// These are copied onto a fresh instance per generation - including <c>Types</c>, but not
+        /// <c>Services</c> or <c>Package</c>, which come from the contract types being generated.
+        /// </remarks>
+        public SchemaGenerationOptions Options { get; } = new SchemaGenerationOptions
         {
             Syntax = ProtoSyntax.Proto3
         };
@@ -132,6 +136,7 @@ namespace ProtoBuf.Grpc.Reflection
                 Origin = Options.Origin,
             };
             options.Services.AddRange(services);
+            options.Types.AddRange(Options.Types);
 
             var model = binderConfiguration.MarshallerCache.TryGetFactory<ProtoBufMarshallerFactory>()?.Model ?? RuntimeTypeModel.Default;
             return model.GetSchema(options);


### PR DESCRIPTION
This PR allows devs to overwrite the default values via the property Options and customize stuff like the generation flags.