### PR TITLE
Add API to capture payload length during marshaller

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/IPayloadLength.cs
+++ b/src/protobuf-net.Grpc/Configuration/IPayloadLength.cs
@@ -1,0 +1,12 @@
+﻿namespace ProtoBuf.Grpc.Configuration;
+
+/// <summary>
+/// Allows capture of the payload length as part of the marshaller serialize/deserialize operation.
+/// </summary>
+public interface IPayloadLength
+{
+    /// <summary>
+    /// Records the payload length.
+    /// </summary>
+    void SetLength(long length);
+}

--- a/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
+++ b/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
@@ -127,13 +127,15 @@ namespace ProtoBuf.Grpc.Configuration
 
         private void ContextualSerialize<T>(T value, global::Grpc.Core.SerializationContext context)
         {
+            long length;
             if (_measuredWriterModel is object)
             {   // forget what we think we know about TypeModel; if we have protobuf-net 3.*, we can do this
 
                 RecordUplevelBufferWrite();
 
                 using var measured = _measuredWriterModel.Measure(value, userState: _userState);
-                int len = checked((int)measured.Length);
+                length = measured.Length;
+                int len = checked((int)length);
                 context.SetPayloadLength(len);
 
                 if (TryGetBufferWriter(context, out var writer))
@@ -150,7 +152,13 @@ namespace ProtoBuf.Grpc.Configuration
             }
             else
             {
-                context.Complete(Serialize<T>(value));
+                var buffer = Serialize<T>(value);
+                length = buffer.Length;
+                context.Complete(buffer);
+            }
+            if (value is IPayloadLength withLength)
+            {
+                withLength.SetLength(length);
             }
         }
 
@@ -177,7 +185,12 @@ namespace ProtoBuf.Grpc.Configuration
             try
             {
                 ros.CopyTo(oversized);
-                return segmentReader.Deserialize<T>(new ArraySegment<byte>(oversized, 0, context.PayloadLength), userState: _userState);
+                var obj = segmentReader.Deserialize<T>(new ArraySegment<byte>(oversized, 0, context.PayloadLength), userState: _userState);
+                if (obj is IPayloadLength withLength)
+                {
+                    withLength.SetLength(context.PayloadLength);
+                }
+                return obj;
             }
             finally
             {

--- a/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
+++ b/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
@@ -165,37 +165,43 @@ namespace ProtoBuf.Grpc.Configuration
         private T ContextualDeserialize<T>(global::Grpc.Core.DeserializationContext context)
         {
             var ros = context.PayloadAsReadOnlySequence();
+            T result;
             if (_squenceReaderModel is object)
             {   // forget what we think we know about TypeModel; if we have protobuf-net 3.*, we can do this
                 RecordUplevelBufferRead();
-                return _squenceReaderModel.Deserialize<T>(ros, userState: _userState);
+                result = _squenceReaderModel.Deserialize<T>(ros, userState: _userState);
             }
-
-            // 2.4.2+ can use array-segments
-            IProtoInput<ArraySegment<byte>> segmentReader = _model;
-
-            // can we go direct to a single segment?
-            if (ros.IsSingleSegment && MemoryMarshal.TryGetArray(ros.First, out var segment))
+            else
             {
-                return segmentReader.Deserialize<T>(segment, userState: _userState);
-            }
 
-            // otherwise; linearize the data
-            var oversized = ArrayPool<byte>.Shared.Rent(context.PayloadLength);
-            try
-            {
-                ros.CopyTo(oversized);
-                var obj = segmentReader.Deserialize<T>(new ArraySegment<byte>(oversized, 0, context.PayloadLength), userState: _userState);
-                if (obj is IPayloadLength withLength)
+                // 2.4.2+ can use array-segments
+                IProtoInput<ArraySegment<byte>> segmentReader = _model;
+
+                // can we go direct to a single segment?
+                if (ros.IsSingleSegment && MemoryMarshal.TryGetArray(ros.First, out var segment))
                 {
-                    withLength.SetLength(context.PayloadLength);
+                    result = segmentReader.Deserialize<T>(segment, userState: _userState);
                 }
-                return obj;
+                else
+                {
+                    // otherwise; linearize the data
+                    var oversized = ArrayPool<byte>.Shared.Rent(context.PayloadLength);
+                    try
+                    {
+                        ros.CopyTo(oversized);
+                        result = segmentReader.Deserialize<T>(new ArraySegment<byte>(oversized, 0, context.PayloadLength), userState: _userState);
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(oversized);
+                    }
+                }
             }
-            finally
+            if (result is IPayloadLength withLength)
             {
-                ArrayPool<byte>.Shared.Return(oversized);
+                withLength.SetLength(context.PayloadLength);
             }
+            return result;
         }
 
         /// <summary>

--- a/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
+++ b/tests/protobuf-net.Grpc.Test.Integration/StreamTests.cs
@@ -73,6 +73,8 @@ namespace protobuf_net.Grpc.Test.Integration
 
         ValueTask<Foo> UnaryAsync(Foo value, CallContext ctx = default);
 
+        ValueTask<FooWithLength> UnaryWithLengthAsync(FooWithLength value, CallContext ctx = default);
+
         Foo UnaryBlocking(Foo value, CallContext ctx = default);
         ValueTask TakeFive(CancellationToken cancellationToken = default);
     }
@@ -276,6 +278,29 @@ namespace protobuf_net.Grpc.Test.Integration
             return value;
         }
 
+        async ValueTask<FooWithLength> IStreamAPI.UnaryWithLengthAsync(FooWithLength value, CallContext ctx)
+        {
+            var scenario = GetScenario(ctx);
+            var sCtx = ctx.ServerCallContext!;
+
+            Log($"unary scenario {scenario}, value {value.Bar}");
+
+            if (scenario == Scenario.FaultBeforeHeaders) Throw("before headers");
+            await sCtx.WriteResponseHeadersAsync(new Metadata { { "prekey", "preval" } });
+
+            if (scenario == Scenario.FaultBeforeTrailers) Throw("before trailers");
+            sCtx.ResponseTrailers.Add("postkey", "postval");
+
+            if (scenario == Scenario.FaultSuccessGoodProducer)
+                throw new RpcException(Status.DefaultSuccess);
+
+            Log("server is complete");
+            value.MoveLengthToPrevious();
+            return value;
+        }
+
+
+
         Foo IStreamAPI.UnaryBlocking(Foo value, CallContext ctx)
         {
             try
@@ -447,6 +472,28 @@ namespace protobuf_net.Grpc.Test.Integration
     {
         [ProtoMember(1)]
         public int Bar { get; set; }
+    }
+
+    [ProtoContract]
+    public class FooWithLength : IPayloadLength
+    {
+        [ProtoMember(1)]
+        public int Bar { get; set; }
+
+        [ProtoMember(2)]
+        public int PreviousLength { get; set; }
+
+        [ProtoIgnore]
+        public int CurrentLength { get; private set; }
+
+        internal void MoveLengthToPrevious()
+        {
+            PreviousLength = CurrentLength;
+            CurrentLength = 0;
+        }
+
+        void IPayloadLength.SetLength(long length)
+            => CurrentLength = checked((int)length);
     }
 
 
@@ -1031,6 +1078,37 @@ namespace protobuf_net.Grpc.Test.Integration
 
             var result = await client.UnaryAsync(new Foo { Bar = 42 }, ctx);
             Assert.Equal(42, result.Bar);
+
+            if ((flags & CallContextFlags.CaptureMetadata) != 0)
+            {
+                var status = ctx.ResponseStatus();
+                Assert.Equal(StatusCode.OK, status.StatusCode);
+                Assert.Equal("", status.Detail);
+                Assert.Equal("preval", (await ctx.ResponseHeadersAsync()).GetString("prekey"));
+                Assert.Equal("postval", ctx.ResponseTrailers().GetString("postkey"));
+            }
+        }
+
+        [DebugTheory]
+        [InlineData(Scenario.RunToCompletion, CallContextFlags.None)]
+        [InlineData(Scenario.RunToCompletion, CallContextFlags.CaptureMetadata)]
+
+        public async Task AsyncUnaryWithLengthSuccess(Scenario scenario, CallContextFlags flags)
+        {
+            await using var svc = CreateClient(out var client);
+
+            var ctx = new CallContext(new CallOptions(headers: new Metadata { { nameof(Scenario), scenario.ToString() } }), flags);
+
+            var clientToServer = new FooWithLength { Bar = 42 };
+            Assert.Equal(0, clientToServer.CurrentLength);
+            Assert.Equal(0, clientToServer.PreviousLength);
+            var serverToClient = await client.UnaryWithLengthAsync(clientToServer, ctx);
+            Assert.Equal(2, clientToServer.CurrentLength);
+            Assert.Equal(0, clientToServer.PreviousLength);
+
+            Assert.Equal(42, serverToClient.Bar);
+            Assert.Equal(4, serverToClient.CurrentLength);
+            Assert.Equal(2, serverToClient.PreviousLength);
 
             if ((flags & CallContextFlags.CaptureMetadata) != 0)
             {


### PR DESCRIPTION
underlying intent here is to allow clients to be informed about payload lengths; we can't do this with `content-length` headers because that doesn't really work with streaming, and gRPC doesn't typically add this (using frames instead)