### PR TITLE
Accept unprefixed release tags, and offset the height so 1.3.0 still lands

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,13 +1,17 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.3",
-  "versionHeightOffset": -1,
+  "versionHeightOffset": -2,
   "assemblyVersion": "1.0",
   "nugetPackageVersion": {
     "semVer": 2
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/tags/\\d+\\.\\d+",
     "^refs/tags/v\\d+\\.\\d+"
-  ]
+  ],
+  "release": {
+    "tagName": "{version}"
+  }
 }


### PR DESCRIPTION
Fixes the failed 1.3.0 release:

```
Tag '1.3.0' does not match the computed version '1.3.0-gc398976539'
```

**One commit deliberately** — see the offset note below.

### Why it failed

This repo has always tagged releases **unprefixed** (`1.3.0`, `1.2.5`, `1.2.2`, `1.1.1`…), but `publicReleaseRefSpec` only listed `^refs/tags/v\d+\.\d+`. So a real release tag was never recognised as a public release, and NB.GV appended a `-g<commit>` suffix.

It went unnoticed because AppVeyor published from `main`, which *does* match — nothing had ever evaluated the version at a tag. `release.yml` is the first thing that does, and it caught this on the first attempt, which is the guard working as intended.

protobuf-net's `version.json` has accepted both forms all along; this brings the two into line. `release.tagName` is added so `nbgv tag` emits the unprefixed form this repo actually uses, rather than nbgv's `v`-prefixed default reintroducing the same mismatch from the other direction.

### Why the offset moves −1 → −2

NB.GV resets commit height only when the **version** field changes — which it did in c398976 (height 1, offset −1, = `1.3.0`). Editing any *other* property does not reset it, so this commit is height 2 and would publish as `1.3.1` without the extra −1.

That is also why this must stay **one commit**: a second commit here would need −3.

### Measured, not inferred

| | |
| --- | --- |
| version height | 2 |
| build number | **0** (height + offset) |
| at an unprefixed tag | **`1.3.0`** — no suffix |
| at the existing `1.3.0` tag | `1.3.0-gc398976539` — the failure, reproduced |

### After merging

Delete the existing `1.3.0` tag **and** its GitHub Release, then re-cut. The tagged commit predates this fix, so re-running the release on it fails identically. Nothing was published, so there is no bad package to retract.