### PR TITLE
BytesValue: parse the slow path by hand, not through RuntimeTypeModel

### DIFF
--- a/src/protobuf-net.Grpc/Internal/BytesValue.cs
+++ b/src/protobuf-net.Grpc/Internal/BytesValue.cs
@@ -252,10 +252,7 @@ public sealed class BytesValue(byte[] oversized, int length, bool pooled)
         while (index < payload.Length)
         {
             var tag = ReadVarint(payload, ref index);
-            var field = (int)(tag >> 3);
-            var wireType = (int)(tag & 7);
-
-            if (field == 1 && wireType == 2)
+            if (tag == PayloadTag)
             {
                 var len = checked((int)ReadVarint(payload, ref index));
                 if (len < 0 || index + len > payload.Length) ThrowMalformed();
@@ -277,11 +274,13 @@ public sealed class BytesValue(byte[] oversized, int length, bool pooled)
             }
             else
             {
-                Skip(payload, ref index, wireType);
+                Skip(payload, ref index, (int)(tag & 7));
             }
         }
         return new(oversized, length, pooled);
     }
+
+    private const ulong PayloadTag = (1 << 3) | 2; // field 1, string
 
     /// <summary>
     /// Skips one unknown field.

--- a/src/protobuf-net.Grpc/Internal/BytesValue.cs
+++ b/src/protobuf-net.Grpc/Internal/BytesValue.cs
@@ -181,69 +181,163 @@ public sealed class BytesValue(byte[] oversized, int length, bool pooled)
         }
     }
 
+    /// <summary>
+    /// Parses any payload <see cref="TryFastParse"/> declines, without going near the runtime model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This used to be <c>RuntimeTypeModel.Default.Deserialize&lt;BytesValue&gt;(...)</c>, and that
+    /// single line was expensive out of all proportion to how often it runs: <c>MarshallerCache</c>
+    /// pre-registers <see cref="Marshaller"/> in a field initialiser, so <em>every</em> consumer -
+    /// including one that never touches a <see cref="Stream"/>-shaped operation - made the whole
+    /// reflective serializer machinery statically reachable. Under native AOT that is metadata ILC
+    /// must keep and analyse; measured on a real publish, removing this root and the one in
+    /// <c>ProtoBufMarshallerFactory</c> took a sample app from 100 IL warnings to 5. Neither alone
+    /// moved it at all - each kept the other's graph alive.
+    /// </para>
+    /// <para>
+    /// The shape is trivial - one <c>bytes</c> field - so parsing it by hand removes the dependency
+    /// outright rather than gating it, and it is kept deliberately small: field 1, plus enough
+    /// unknown-field skipping not to regress a peer that sends something extra. See
+    /// <see cref="Skip"/> for the one capability knowingly dropped.
+    /// </para>
+    /// <para>
+    /// This does not use protobuf-net's own reader APIs either: the assembly compiles against
+    /// protobuf-net 2.x (<c>ProtoBufNet2Version</c>), where <c>ProtoReader.State</c> does not exist.
+    /// If that pin is ever raised to 3.x, most of this could go.
+    /// </para>
+    /// <para>
+    /// Field 1 uses <b>replace</b> semantics if it somehow appears twice, matching the protobuf rule
+    /// for a non-repeated field (last one wins). The runtime model would have <em>concatenated</em>,
+    /// via protobuf-net's append behaviour for <c>byte[]</c>; that difference is unreachable in
+    /// practice, since each chunk is its own gRPC message and <see cref="Serialize"/> writes field 1
+    /// exactly once, so no legacy opt-out is offered.
+    /// </para>
+    /// </remarks>
     private static BytesValue SlowParse(in ReadOnlySequence<byte> payload)
     {
-        IProtoInput<Stream> model = RuntimeTypeModel.Default;
-        var len = payload.Length;
-        // use protobuf-net v3 API if available
-        if (model is IProtoInput<ReadOnlySequence<byte>> v3)
+        if (payload.IsSingleSegment)
         {
-            return v3.Deserialize<BytesValue>(payload);
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+            return Parse(payload.FirstSpan);
+#else
+            return Parse(payload.First.Span);
+#endif
         }
 
-        // use protobuf-net v2 API
-        MemoryStream ms;
-        if (payload.IsSingleSegment && MemoryMarshal.TryGetArray(payload.First, out var segment))
+        // multi-segment: linearize into a leased buffer, which is simpler (and cheaper) than
+        // threading a segment-crossing reader through what is a handful of bytes of framing
+        var length = checked((int)payload.Length);
+        var leased = ArrayPool<byte>.Shared.Rent(length);
+        try
         {
-            ms = new MemoryStream(segment.Array!, segment.Offset, segment.Count, writable: false, publiclyVisible: true);
+            payload.CopyTo(leased);
+            return Parse(new ReadOnlySpan<byte>(leased, 0, length));
         }
-        else
+        finally
         {
-            ms = new MemoryStream();
-            ms.SetLength(len);
-            if (ms.TryGetBuffer(out var buffer) && buffer.Count >= len)
+            ArrayPool<byte>.Shared.Return(leased);
+        }
+    }
+
+    private static BytesValue Parse(ReadOnlySpan<byte> payload)
+    {
+        // an empty payload is a legal encoding of an empty BytesValue - every field defaulted - and
+        // is one of the ways TryFastParse declines, so it is a normal outcome rather than an error
+        byte[] oversized = [];
+        int length = 0;
+        bool pooled = false;
+
+        var index = 0;
+        while (index < payload.Length)
+        {
+            var tag = ReadVarint(payload, ref index);
+            var field = (int)(tag >> 3);
+            var wireType = (int)(tag & 7);
+
+            if (field == 1 && wireType == 2)
             {
-                payload.CopyTo(buffer.AsSpan());
+                var len = checked((int)ReadVarint(payload, ref index));
+                if (len < 0 || index + len > payload.Length) ThrowMalformed();
+
+                if (pooled) ArrayPool<byte>.Shared.Return(oversized); // replace, not append
+                if (len == 0)
+                {
+                    oversized = [];
+                    pooled = false;
+                }
+                else
+                {
+                    oversized = ArrayPool<byte>.Shared.Rent(len);
+                    pooled = true;
+                    payload.Slice(index, len).CopyTo(oversized);
+                }
+                length = len;
+                index += len;
             }
             else
             {
-#if !(NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER)
-                byte[] leased = [];
-#endif
-                foreach (var chunk in payload)
-                {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
-                            ms.Write(chunk.Span);
-#else
-                    if (MemoryMarshal.TryGetArray(chunk, out segment))
-                    {
-                        ms.Write(segment.Array!, segment.Offset, segment.Count);
-                    }
-                    else
-                    {
-                        if (leased.Length < segment.Count)
-                        {
-                            ArrayPool<byte>.Shared.Return(leased);
-                            leased = ArrayPool<byte>.Shared.Rent(segment.Count);
-                        }
-                        segment.AsSpan().CopyTo(leased);
-                        ms.Write(leased, 0, segment.Count);
-                    }
-#endif
-                }
-#if !(NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER)
-                if (leased.Length != 0)
-                {
-                    ArrayPool<byte>.Shared.Return(leased);
-                }
-#endif
-                Debug.Assert(ms.Position == len, "should have written all bytes");
-                ms.Position = 0;
+                Skip(payload, ref index, wireType);
             }
         }
-        Debug.Assert(ms.Position == 0 && ms.Length == len, "full payload should be ready to read");
-        return model.Deserialize<BytesValue>(ms);
+        return new(oversized, length, pooled);
     }
+
+    /// <summary>
+    /// Skips one unknown field.
+    /// </summary>
+    /// <remarks>
+    /// Groups (wire types 3 and 4) are deliberately <em>not</em> supported, and that is the one place
+    /// this is less capable than the runtime model it replaced. <see cref="BytesValue"/> is
+    /// <c>.google.protobuf.BytesValue</c> - a frozen well-known type with exactly one field - so a
+    /// group inside it is not a payload anyone can produce by evolving a schema. Supporting it cost
+    /// recursion and a depth counter for a case that cannot arise, so it throws instead.
+    /// </remarks>
+    private static void Skip(ReadOnlySpan<byte> payload, ref int index, int wireType)
+    {
+        switch (wireType)
+        {
+            case 0: // varint
+                ReadVarint(payload, ref index);
+                break;
+            case 1: // fixed64
+                index += 8;
+                break;
+            case 2: // length-delimited
+                // NB two statements, deliberately: `index += ReadVarint(payload, ref index)` reads
+                // the left operand *before* the call advances `index` through the ref parameter, so
+                // the length prefix's own bytes get counted twice and the skip lands short
+                var skip = checked((int)ReadVarint(payload, ref index));
+                index += skip;
+                break;
+            case 5: // fixed32
+                index += 4;
+                break;
+            default: // 3/4 groups, 6/7 do not exist
+                ThrowMalformed();
+                break;
+        }
+        if (index > payload.Length) ThrowMalformed();
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> payload, ref int index)
+    {
+        ulong value = 0;
+        var shift = 0;
+        while (index < payload.Length)
+        {
+            var b = payload[index++];
+            value |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0) return value;
+            shift += 7;
+            if (shift > 63) break;
+        }
+        ThrowMalformed();
+        return 0;
+    }
+
+    private static void ThrowMalformed()
+        => throw new InvalidOperationException($"Invalid {nameof(BytesValue)} payload");
 
     internal static BytesValue? TryFastParse(ReadOnlySpan<byte> start, in ReadOnlySequence<byte> payload)
     {

--- a/tests/protobuf-net.Grpc.Test/BytesValueMarshallerTests.cs
+++ b/tests/protobuf-net.Grpc.Test/BytesValueMarshallerTests.cs
@@ -9,6 +9,7 @@ namespace protobuf_net.Grpc.Test;
 
 #pragma warning disable CS0618 // all marked obsolete!
 
+[Collection(BytesValueCollection.Name)]
 public class BytesValueMarshallerTests
 {
     [Fact]

--- a/tests/protobuf-net.Grpc.Test/BytesValueSlowParseTests.cs
+++ b/tests/protobuf-net.Grpc.Test/BytesValueSlowParseTests.cs
@@ -1,0 +1,193 @@
+using Grpc.Core;
+using ProtoBuf.Grpc.Internal;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test;
+
+#pragma warning disable CS0618 // all marked obsolete!
+
+/// <summary>
+/// Serializes the BytesValue suites against each other.
+/// </summary>
+/// <remarks>
+/// <c>BytesValue.FastPassMiss</c> is a process-wide DEBUG counter, and
+/// <c>BytesValueMarshallerTests.TestFastParseAndFormat</c> asserts that it does not move across its
+/// own round-trip. The slow-parse suite exists precisely to *miss* the fast path, so run in parallel
+/// (xUnit's default across classes) it makes that assertion flap. Note this only bites in DEBUG,
+/// which is why a Release-configuration run does not show it.
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class BytesValueCollection
+{
+    public const string Name = "BytesValue";
+}
+
+/// <summary>
+/// Covers the payloads <c>BytesValue.TryFastParse</c> declines, which is everything the hand-written
+/// slow path is for.
+/// </summary>
+/// <remarks>
+/// These used to be handled by <c>RuntimeTypeModel.Default</c>. That was replaced because it made the
+/// whole reflective serializer machinery statically reachable from every consumer - see the remarks
+/// on <c>SlowParse</c> - so this suite exists to show the replacement is equivalent, including for
+/// the shapes only a non-protobuf-net peer would send.
+/// </remarks>
+[Collection(BytesValueCollection.Name)]
+public class BytesValueSlowParseTests
+{
+    private static BytesValue Parse(params byte[] payload)
+        => BytesValue.Marshaller.ContextualDeserializer(new SingleSegmentContext(payload));
+
+    /// <summary>Field 1, length-delimited, with the given contents.</summary>
+    private static IEnumerable<byte> Field1(params byte[] value)
+    {
+        yield return 0x0A;
+        yield return checked((byte)value.Length); // callers here stay under 128 bytes
+        foreach (var b in value) yield return b;
+    }
+
+    [Fact]
+    public void EmptyPayloadIsAnEmptyValue()
+    {
+        // a BytesValue with everything defaulted encodes as zero bytes - legal protobuf, and one of
+        // the ways TryFastParse declines (it reads four zero bytes and matches no case)
+        var result = Parse();
+        Assert.NotNull(result);
+        Assert.True(result.IsEmpty);
+        Assert.Equal(0, result.Length);
+        Assert.False(result.IsPooled);
+    }
+
+    [Fact]
+    public void ExplicitEmptyBytesIsAnEmptyValue()
+    {
+        var result = Parse(0x0A, 0x00);
+        Assert.NotNull(result);
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public void UnknownFieldBeforePayloadIsSkipped()
+    {
+        // field 2, varint, value 42 - then our field; the leading byte is not 0x0A, so fast parse declines
+        var payload = new byte[] { 0x10, 0x2A }.Concat(Field1(1, 2, 3)).ToArray();
+        var result = Parse(payload);
+        Assert.True(result.Span.SequenceEqual(new byte[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void UnknownFieldAfterPayloadIsSkipped()
+    {
+        // fast parse declines this one on length: header + bytes != payload length
+        var payload = Field1(4, 5, 6).Concat(new byte[] { 0x10, 0x2A }).ToArray();
+        var result = Parse(payload);
+        Assert.True(result.Span.SequenceEqual(new byte[] { 4, 5, 6 }));
+    }
+
+    [Theory]
+    [InlineData(1, 8)]   // fixed64
+    [InlineData(5, 4)]   // fixed32
+    public void UnknownFixedWidthFieldsAreSkipped(int wireType, int width)
+    {
+        var tag = (byte)((2 << 3) | wireType);
+        var payload = new[] { tag }.Concat(new byte[width])
+            .Concat(Field1(7)).ToArray();
+        var result = Parse(payload);
+        Assert.True(result.Span.SequenceEqual(new byte[] { 7 }));
+    }
+
+    [Fact]
+    public void UnknownLengthDelimitedFieldIsSkipped()
+    {
+        // field 2, length-delimited, 3 bytes of junk
+        var payload = new byte[] { 0x12, 0x03, 0xFF, 0xFF, 0xFF }.Concat(Field1(9)).ToArray();
+        var result = Parse(payload);
+        Assert.True(result.Span.SequenceEqual(new byte[] { 9 }));
+    }
+
+    [Fact]
+    public void UnknownGroupThrows()
+    {
+        // Pins a deliberate limit rather than an aspiration. The runtime model would have skipped
+        // this; supporting it costs recursion and a depth counter for a payload nobody can produce,
+        // because BytesValue is .google.protobuf.BytesValue - frozen, one field, no schema evolution
+        // that could introduce a group. If that ever stops being true, this test is the tripwire.
+        var payload = new byte[] { 0x13, 0x18, 0x2A, 0x14 }.Concat(Field1(11)).ToArray();
+        Assert.ThrowsAny<Exception>(() => Parse(payload));
+    }
+
+    [Fact]
+    public void RepeatedFieldOneReplaces()
+    {
+        // The protobuf rule for a non-repeated field is "last one wins". Note the runtime model would
+        // have *concatenated* these, via protobuf-net's append behaviour for byte[] - this is the one
+        // deliberate behaviour change, and it is unreachable from anything we write, because each
+        // chunk is its own gRPC message and Serialize emits field 1 exactly once.
+        var payload = Field1(1, 2, 3).Concat(Field1(9, 9)).ToArray();
+        var result = Parse(payload);
+        Assert.True(result.Span.SequenceEqual(new byte[] { 9, 9 }));
+        Assert.Equal(2, result.Length);
+    }
+
+    [Fact]
+    public void MultiSegmentPayloadIsLinearized()
+    {
+        // splits the payload mid-field, which is the case the single-span parser cannot see directly
+        var payload = new byte[] { 0x10, 0x2A }.Concat(Field1(1, 2, 3, 4, 5)).ToArray();
+        var result = BytesValue.Marshaller.ContextualDeserializer(
+            new MultiSegmentContext(payload, chunkSize: 3));
+        Assert.True(result.Span.SequenceEqual(new byte[] { 1, 2, 3, 4, 5 }));
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x0A })]              // truncated: length prefix missing
+    [InlineData(new byte[] { 0x0A, 0x05, 1, 2 })]  // truncated: fewer bytes than declared
+    [InlineData(new byte[] { 0x14 })]              // end-group with no start
+    [InlineData(new byte[] { 0x0F })]              // wire type 7 does not exist
+    public void MalformedPayloadsThrow(byte[] payload)
+        => Assert.ThrowsAny<Exception>(() => Parse(payload));
+
+    private sealed class SingleSegmentContext(byte[] chunk) : DeserializationContext
+    {
+        public override int PayloadLength => chunk.Length;
+        public override byte[] PayloadAsNewBuffer() => (byte[])chunk.Clone();
+        public override ReadOnlySequence<byte> PayloadAsReadOnlySequence() => new(chunk);
+    }
+
+    private sealed class MultiSegmentContext(byte[] chunk, int chunkSize) : DeserializationContext
+    {
+        public override int PayloadLength => chunk.Length;
+        public override byte[] PayloadAsNewBuffer() => (byte[])chunk.Clone();
+
+        public override ReadOnlySequence<byte> PayloadAsReadOnlySequence()
+        {
+            Segment? first = null, last = null;
+            for (var offset = 0; offset < chunk.Length; offset += chunkSize)
+            {
+                var len = Math.Min(chunkSize, chunk.Length - offset);
+                var next = new Segment(new ReadOnlyMemory<byte>(chunk, offset, len), last);
+                first ??= next;
+                last = next;
+            }
+            if (first is null || last is null) return default;
+            return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+        }
+
+        private sealed class Segment : ReadOnlySequenceSegment<byte>
+        {
+            public Segment(ReadOnlyMemory<byte> memory, Segment? previous)
+            {
+                Memory = memory;
+                if (previous is not null)
+                {
+                    RunningIndex = previous.RunningIndex + previous.Memory.Length;
+                    previous.Next = this;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The second of the two `RuntimeTypeModel` roots — and the one that actually moves the needle. Follows protobuf-net/protobuf-net.Grpc#365.

`BytesValue.SlowParse` did `IProtoInput<Stream> model = RuntimeTypeModel.Default`. That single line is expensive out of all proportion to how often it runs: `MarshallerCache` pre-registers `BytesValue.Marshaller` in a **field initialiser**, so *every* consumer — including one that never touches a `Stream`-shaped operation — made the entire reflective serializer machinery statically reachable.

## Measured

Native `win-x64` publish of protobuf-net's `src/AotGrpcSmoke` — real client, real server, real socket:

| | IL warnings | bytes |
| --- | ---: | ---: |
| baseline | 100 | 15,015,936 |
| marshaller-factory gates only (#365) | 100 | 15,019,520 |
| this change only | 100 | 15,017,984 |
| **both** | **5** | **14,472,192** |

**An AND, not an OR** — either root alone keeps the other's graph alive, so each change in isolation looks worthless. Together: **−95 warnings, −543,744 bytes (−3.6%)**, and the native binary passes end to end.

## Deliberately small

Field 1, plus unknown-field skipping for the four simple wire types. **Groups are not supported** — the one capability knowingly dropped versus the runtime model. `BytesValue` is `.google.protobuf.BytesValue`: frozen, one field, so no schema evolution can introduce a group, and supporting it cost recursion plus a depth counter for a payload nobody can produce.

The skipping that *remains* is eight lines and does prevent a regression: a peer sending a trailing field works today, and throwing there would break a byte-streaming path at run time.

It avoids protobuf-net's reader APIs too — this assembly compiles against protobuf-net **2.x** (`ProtoBufNet2Version`), where `ProtoReader.State` does not exist. **If that pin is ever raised to 3.x, most of this could go**; worth a separate conversation, since it's a smaller lever than working around it.

## One deliberate behaviour change

Field 1 uses **replace** semantics if it somehow appears twice, matching the protobuf rule for a non-repeated field; the runtime model would have **concatenated**. Unreachable from anything we write — each chunk is its own gRPC message and `Serialize` emits field 1 exactly once — so unlike protobuf-net's own `byte[]` handling, no legacy append opt-out is offered.

## Tests

Cover every shape `TryFastParse` declines: **empty payload** (a legal encoding of an empty value, and a *normal* outcome rather than an error), unknown fields before and after, the four skippable wire types, multi-segment sequences split mid-field, repeated field 1, groups (pinning the refusal, so there's a tripwire if that assumption changes), and four malformed payloads.

Two bugs they caught:

- `index += ReadVarint(payload, ref index)` reads the left operand **before** the call advances `index` through the `ref` parameter, so skipping a length-delimited field landed short.
- `BytesValue.FastPassMiss` is a process-wide `#if DEBUG` counter, and `TestFastParseAndFormat` asserts it doesn't move across its own round-trip — a suite that deliberately *misses* the fast path made that flap once xUnit ran the classes in parallel. Both are now in one collection. **Only visible in DEBUG**, which is why a Release run didn't show it.

Green in Debug and Release, all TFMs.