### PR TITLE
Fixed custom attributes not collected with subservice interface (resolved #330)

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -64,7 +64,7 @@ namespace ProtoBuf.Grpc.Configuration
                     var serviceContractSimplifiedExceptions = serviceImplSimplifiedExceptions ||
                                                               typeToBindItsMethods.IsDefined(
                                                                   typeof(SimpleRpcExceptionsAttribute));
-                    var bindCtx = new ServiceBindContext(typeToBindItsMethods, serviceType, state, binderConfiguration.Binder);
+                    var bindCtx = new ServiceBindContext(serviceContract, serviceType, state, binderConfiguration.Binder);
                     foreach (var op in ContractOperation.FindOperations(binderConfiguration, typeToBindItsMethods, this))
                     {
                         if (ServerInvokerLookup.TryGetValue(op.MethodType, op.Context, op.Arg, op.Result, op.Void, out var invoker)

--- a/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServerBinder.cs
@@ -64,7 +64,7 @@ namespace ProtoBuf.Grpc.Configuration
                     var serviceContractSimplifiedExceptions = serviceImplSimplifiedExceptions ||
                                                               typeToBindItsMethods.IsDefined(
                                                                   typeof(SimpleRpcExceptionsAttribute));
-                    var bindCtx = new ServiceBindContext(serviceContract, serviceType, state, binderConfiguration.Binder);
+                    var bindCtx = new ServiceBindContext(typeToBindItsMethods, serviceType, state, binderConfiguration.Binder);
                     foreach (var op in ContractOperation.FindOperations(binderConfiguration, typeToBindItsMethods, this))
                     {
                         if (ServerInvokerLookup.TryGetValue(op.MethodType, op.Context, op.Arg, op.Result, op.Void, out var invoker)

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -211,7 +211,7 @@ namespace ProtoBuf.Grpc.Configuration
         {
             if (contractType != serviceType & serviceMethod is object)
             {
-                var map = GetMap(contractType, serviceType);
+                var map = GetMap(serviceMethod.DeclaringType ?? contractType, serviceType);
                 var from = map.InterfaceMethods;
                 var to = map.TargetMethods;
                 int end = Math.Min(from.Length, to.Length);

--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -209,7 +209,7 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         public MethodInfo? GetMethodImplementation(MethodInfo serviceMethod, Type contractType, Type serviceType)
         {
-            if (contractType != serviceType & serviceMethod is object)
+            if (contractType != serviceType && serviceMethod is object)
             {
                 var map = GetMap(serviceMethod.DeclaringType ?? contractType, serviceType);
                 var from = map.InterfaceMethods;

--- a/tests/protobuf-net.Grpc.Test/Issues/Issue330.cs
+++ b/tests/protobuf-net.Grpc.Test/Issues/Issue330.cs
@@ -1,0 +1,74 @@
+using Grpc.Core;
+using ProtoBuf.Grpc.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test.Issues
+{
+    // https://github.com/protobuf-net/protobuf-net.Grpc/issues/330
+    // operations declared on a [SubService] interface are bound against the top-level
+    // [Service] contract; the implementing method must still be located (so that attributes
+    // on the implementation are surfaced as metadata), *without* losing the attributes of
+    // the top-level contract type.
+    public class Issue330
+    {
+        [Theory]
+        [InlineData("/i330/TopLevel", "ContractType,ContractMethod,ImplType,TopLevelImpl")]
+        [InlineData("/i330/ImplicitSub", "ContractType,SubContractMethod,ImplType,ImplicitSubImpl")]
+        [InlineData("/i330/ExplicitSub", "ContractType,SubContractExplicitMethod,ImplType,ExplicitSubImpl")]
+        public void MetadataFromSubServiceOperations(string fullName, string expected)
+        {
+            var binder = new MetadataServerBinder();
+            Assert.Equal(3, binder.Bind<Issue330Service>(null!));
+
+            var actual = string.Join(",", binder.Metadata[fullName].OfType<SomethingAttribute>().Select(x => x.Value));
+            Assert.Equal(expected, actual);
+        }
+
+        [SubService]
+        [Something("SubContractType")]
+        public interface IIssue330Sub
+        {
+            [Something("SubContractMethod")]
+            void ImplicitSub();
+
+            [Something("SubContractExplicitMethod")]
+            void ExplicitSub();
+        }
+
+        [Service("i330")]
+        [Something("ContractType")]
+        public interface IIssue330Service : IIssue330Sub
+        {
+            [Something("ContractMethod")]
+            void TopLevel();
+        }
+
+        [Something("ImplType")]
+        public class Issue330Service : IIssue330Service
+        {
+            [Something("TopLevelImpl")]
+            public void TopLevel() { }
+
+            [Something("ImplicitSubImpl")]
+            public void ImplicitSub() { }
+
+            [Something("ExplicitSubImpl")]
+            void IIssue330Sub.ExplicitSub() { }
+        }
+
+        // mirrors what ServicesExtensions does for real: metadata per bound method
+        private sealed class MetadataServerBinder : ServerBinder
+        {
+            public Dictionary<string, IList<object>> Metadata { get; } = [];
+
+            protected override bool TryBind<TService, TRequest, TResponse>(ServiceBindContext bindContext,
+                Method<TRequest, TResponse> method, MethodStub<TService> stub)
+            {
+                Metadata.Add(method.FullName, bindContext.GetMetadata(stub.Method));
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Custom attributes used to decorate methods which came from an interface used for "SubService" aren't collected.

With this fix this code works:
```cs
[SubService]
public interface ITestSubService
{
   [Operation]
   ValueTask DoSomethingCommon(CallContext context);
}

[Service]
public interface ITestService : ITestSubService
{
   [Operation]
   ValueTask DoSomethingSpecific(CallContext context);
}

internal class TestService : ITestService
{
   // This method came from "SubService" interface and the "CustomAttribute" now is collected by endpoint metadata
   [CustomAttribute]
   public ValueTask DoSomethingCommon(CallContext context)
   {
      // ...
   }

   [CustomAttribute]
   public ValueTask DoSomethingSpecific(CallContext context)
   {
      // ...
   }
}
```