### PR TITLE
Key the interface-mapping cache on (contract, service), not contract alone

### DIFF
--- a/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
+++ b/src/protobuf-net.Grpc/Configuration/ServiceBinder.cs
@@ -20,14 +20,20 @@ namespace ProtoBuf.Grpc.Configuration
         /// </summary>
         protected ServiceBinder() { }
 
-        private static readonly ConcurrentDictionary<Type, InterfaceMapping> s_map = new ConcurrentDictionary<Type, InterfaceMapping>();
+        // the key is the *pair*, deliberately: an interface mapping is a property of the contract and
+        // of the type implementing it, so keying on the contract alone hands the second implementation
+        // of a shared contract the first one's TargetMethods - and callers then read attributes off
+        // the wrong class's methods
+        private static readonly ConcurrentDictionary<(Type ContractType, Type ServiceType), InterfaceMapping> s_map
+            = new ConcurrentDictionary<(Type ContractType, Type ServiceType), InterfaceMapping>();
         private static InterfaceMapping GetMap(Type contractType, Type serviceType)
         {
-            if (!s_map.TryGetValue(contractType, out var interfaceMapping))
+            var key = (contractType, serviceType);
+            if (!s_map.TryGetValue(key, out var interfaceMapping))
             {   // note: it doesn't matter if this ends up getting called more than once
                 // in a race condition - we don't need to block etc (the result will be compatible)
                 interfaceMapping = serviceType.GetInterfaceMap(contractType);
-                s_map[contractType] = interfaceMapping;
+                s_map[key] = interfaceMapping;
             }
             return interfaceMapping;
         }

--- a/tests/protobuf-net.Grpc.Test/ServiceBinderMetadataTests.cs
+++ b/tests/protobuf-net.Grpc.Test/ServiceBinderMetadataTests.cs
@@ -1,0 +1,72 @@
+using ProtoBuf.Grpc.Configuration;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace protobuf_net.Grpc.Test;
+
+public class ServiceBinderMetadataTests
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class MarkAttribute(string who) : Attribute
+    {
+        public string Who { get; } = who;
+    }
+
+    // deliberately private to this test: the mapping cache is process-wide and keyed on these types,
+    // so contract types shared with other suites would make the result depend on test order
+    private interface IShared { void Op(); }
+
+    private sealed class FirstImpl : IShared
+    {
+        [Mark(nameof(FirstImpl))]
+        public void Op() { }
+    }
+
+    private sealed class SecondImpl : IShared
+    {
+        [Mark(nameof(SecondImpl))]
+        public void Op() { }
+    }
+
+    /// <summary>
+    /// Two classes implementing one contract must each report their own method's attributes.
+    /// </summary>
+    /// <remarks>
+    /// An interface mapping is a property of the (contract, implementation) <em>pair</em>. The cache
+    /// behind <c>GetMethodImplementation</c> used to be keyed on the contract alone, so the second
+    /// implementation asked for was handed the first one's <c>TargetMethods</c> and attributes were
+    /// read off the wrong class - silently, and order-dependently. That matters beyond metadata
+    /// tidiness: an <c>[Authorize]</c> on one implementation would apply to, or go missing from, the
+    /// other.
+    /// </remarks>
+    [Fact]
+    public void MetadataIsPerImplementation()
+    {
+        var op = typeof(IShared).GetMethod(nameof(IShared.Op))!;
+
+        // order matters: before the fix, whichever was asked for first populated the cache for both
+        Assert.Equal(nameof(FirstImpl), MarkFor(op, typeof(FirstImpl)));
+        Assert.Equal(nameof(SecondImpl), MarkFor(op, typeof(SecondImpl)));
+
+        // and again in reverse, so the test cannot pass by luck of ordering
+        Assert.Equal(nameof(SecondImpl), MarkFor(op, typeof(SecondImpl)));
+        Assert.Equal(nameof(FirstImpl), MarkFor(op, typeof(FirstImpl)));
+
+        static string MarkFor(System.Reflection.MethodInfo op, Type serviceType)
+            => ServiceBinder.Default.GetMetadata(op, typeof(IShared), serviceType)
+                .OfType<MarkAttribute>().Select(static x => x.Who).SingleOrDefault() ?? "(none)";
+    }
+
+    /// <summary>The same thing one level down, against the API that actually does the lookup.</summary>
+    [Fact]
+    public void MethodImplementationIsPerImplementation()
+    {
+        var op = typeof(IShared).GetMethod(nameof(IShared.Op))!;
+
+        Assert.Equal(typeof(FirstImpl),
+            ServiceBinder.Default.GetMethodImplementation(op, typeof(IShared), typeof(FirstImpl))?.DeclaringType);
+        Assert.Equal(typeof(SecondImpl),
+            ServiceBinder.Default.GetMethodImplementation(op, typeof(IShared), typeof(SecondImpl))?.DeclaringType);
+    }
+}


### PR DESCRIPTION
Split out of the discussion on #369, where it was noticed but is not that PR's job.

An interface mapping is a property of the **pair** — which methods implement a contract depends on the implementing type. `ServiceBinder` cached it under the contract type only:

```csharp
if (!s_map.TryGetValue(contractType, out var interfaceMapping))
{
    interfaceMapping = serviceType.GetInterfaceMap(contractType);
    s_map[contractType] = interfaceMapping;   // key ignores serviceType
}
```

So the second class implementing a shared contract is handed the first one's `TargetMethods`, and `GetMetadata` then reads attributes off the wrong class's methods.

## Reproduced against shipped 1.3.0

```
GetMetadata(..., IContract, ImplA) -> ImplA.Op   (expect ImplA.Op)
GetMetadata(..., IContract, ImplB) -> ImplA.Op   (expect ImplB.Op)
```

Silent, and **order-dependent** — whichever implementation is bound first wins for every other.

It matters beyond metadata tidiness: endpoint metadata is where `[Authorize]` lives, so one implementation's authorization can apply to, or go missing from, another.

## On the existing comment

The comment justified not locking, on the grounds that a racing recompute "will be compatible". That is true for a race on the same pair — and still is, the fix keeps the lock-free shape. It was not true across different service types, which is what this changes.

## Tests

Two, covering the observable behaviour (`GetMetadata`) and the API that actually does the lookup (`GetMethodImplementation`). Both assert in **both orders**, so they cannot pass by luck of ordering, and **both fail before this change** with exactly the symptom above:

```
Assert.Equal() Failure: Strings differ
Expected: "SecondImpl"
Actual:   "FirstImpl"
```

The contract and its implementations are private to the test class deliberately — the cache is process-wide and keyed on these types, so a contract shared with another suite would make the result depend on test order.

Green in Debug and Release across all TFMs.

<sub>Note: I saw one intermittent failure in the Integration suite while verifying, in a different assembly/TFM on each occurrence and not reproducing across three further full runs — it looks like the pre-existing timing flake reported in #364, unrelated to this change, but I did not capture the test name to be sure.</sub>