### PR TITLE
Use #if NET for "modern .NET", not assorted version floors

### DIFF
--- a/src/protobuf-net.Grpc/Client/GrpcClientFactory.cs
+++ b/src/protobuf-net.Grpc/Client/GrpcClientFactory.cs
@@ -11,7 +11,7 @@ namespace ProtoBuf.Grpc.Client
     /// </summary>
     public static class GrpcClientFactory
     {
-#if NET5_0_OR_GREATER
+#if NET
         // it is *intended* that this attribute usage will help the linker not remove things that we need
         // see: https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#dynamicallyaccessedmembers
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]

--- a/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
+++ b/src/protobuf-net.Grpc/Configuration/ProtoBufMarshallerFactory.cs
@@ -62,7 +62,7 @@ namespace ProtoBuf.Grpc.Configuration
 
         private static MarshallerFactory CreateDefault()
         {
-#if NET5_0_OR_GREATER
+#if NET
             if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
             {
                 return UnavailableMarshallerFactory.Instance;
@@ -110,7 +110,7 @@ namespace ProtoBuf.Grpc.Configuration
             // the null/default-model path is the reflective one, so it is gated exactly as Default is;
             // naming RuntimeTypeModel.Default unconditionally here would re-root everything that the
             // gate on Default was there to remove
-#if NET5_0_OR_GREATER
+#if NET
             if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
             {
                 if (model is null) return Default; // i.e. UnavailableMarshallerFactory

--- a/src/protobuf-net.Grpc/Internal/BytesValue.cs
+++ b/src/protobuf-net.Grpc/Internal/BytesValue.cs
@@ -218,7 +218,7 @@ public sealed class BytesValue(byte[] oversized, int length, bool pooled)
     {
         if (payload.IsSingleSegment)
         {
-#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
             return Parse(payload.FirstSpan);
 #else
             return Parse(payload.First.Span);

--- a/src/protobuf-net.Grpc/Internal/Reshape.ByteStream.cs
+++ b/src/protobuf-net.Grpc/Internal/Reshape.ByteStream.cs
@@ -188,7 +188,7 @@ partial class Reshape
     {
         try
         {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
         await // IDisposable is up-level
 #endif
             using var stream = await source;

--- a/src/protobuf-net.Grpc/Internal/Reshape.cs
+++ b/src/protobuf-net.Grpc/Internal/Reshape.cs
@@ -221,11 +221,11 @@ namespace ProtoBuf.Grpc.Internal
             => new WriterObserver<T>().Subscribe(reader, writer);
 
         private sealed class WriterObserver<T> : IObserver<T>, IValueTaskSource<bool>
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
             , IThreadPoolWorkItem
 #endif
         {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
             void IThreadPoolWorkItem.Execute() => Activate();
 #else
             private static readonly WaitCallback s_Activate = static state => Unsafe.As<WriterObserver<T>>(state)!.Activate();
@@ -266,7 +266,7 @@ namespace ProtoBuf.Grpc.Internal
                             debugStep = nameof(_backlog.Dequeue);
                             lock (_backlog)
                             {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
                                 if (!_backlog.TryDequeue(out next!)) break;
 #else
                                 if (_backlog.Count == 0) break;
@@ -339,7 +339,7 @@ namespace ProtoBuf.Grpc.Internal
                 {
                     _flags &= ~StateFlags.NeedsActivation;
                     Debug.WriteLine("Activating", ToString());
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
                     ThreadPool.UnsafeQueueUserWorkItem(this, false);
 #else
                     ThreadPool.UnsafeQueueUserWorkItem(s_Activate, this);


### PR DESCRIPTION
Follow-up to the discussion on #359. Nine gates across five files; **no `NET5_0_*`, `NET6_0_*`, `NET7_0_*` or `NETCOREAPP*` symbols remain anywhere in `src`.**

```
NET5_0_OR_GREATER                                     -> NET          (x3)
NETCOREAPP3_1_OR_GREATER                              -> NET          (x3)
NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER        -> ... || NET
NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER -> ... || NET
NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER -> ... || NET
```

## Why this is safe, not just convenient

`NET` is emitted precisely when `TargetFrameworkIdentifier` is `.NETCoreApp` **and** the version is >= 5.0 — straight from the SDK's `GenerateTargetFrameworkDefineConstants` target in `Microsoft.NET.Sdk.BeforeCommon.targets`:

```xml
<_FrameworkIdentifierForImplicitDefine
    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                VersionGreaterThanOrEquals($(TargetFrameworkVersion), 5.0) ">NET</…>
<VersionlessImplicitFrameworkDefine>$(_FrameworkIdentifierForImplicitDefine)</…>
```

So `NET` is **structurally identical** to `NET5_0_OR_GREATER`, not merely equal for our TFM list. The `NETCOREAPP3_x` ones widen to include netcoreapp3.x, which this repo doesn't target and won't be adding.

One thing worth knowing, since it looks alarming at first: the very next line in that target sets the same property to `NET` for `.NETFramework` too — but only *after* the versionless define has been captured. That line is what produces `NET472`/`NET48_OR_GREATER`; bare `NET` cannot match .NET Framework.

## Two deliberately left alone

Both are real API floors rather than a proxy for "modern .NET":

- **`!NET8_0_OR_GREATER`** around the `ExperimentalAttribute` polyfill. Equivalent to `!NET` for today's TFM set, but the attribute arrived in .NET 8 — `!NET` would silently drop the polyfill if net5/6/7 were ever added, which is exactly the kind of breakage a tidy-up should not introduce.
- **`NETSTANDARD2_0`** in `ProxyEmitter` (`CreateTypeInfo` vs `CreateType`), a single-TFM gap.

## Verified

With the workflow's own commands rather than an approximation, in **both** configurations — build plus `dotnet test Build.csproj` gives 12 × "Test Run Successful." and zero failures in Release *and* in Debug.

No overlap with #359 (that one touches `ProxyEmitter`/`ProxyModuleHelper`; this touches `GrpcClientFactory`, `ProtoBufMarshallerFactory`, `BytesValue`, `Reshape`, `Reshape.ByteStream`), so they merge cleanly in either order.
