### PR TITLE
Adopt protobuf-net's get-version scripts

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.9.50",
+      "commands": [
+        "nbgv"
+      ]
+    }
+  }
+}

--- a/get-version.ps1
+++ b/get-version.ps1
@@ -1,0 +1,21 @@
+# Shows the version the current commit computes - i.e. the tag name to type into the GitHub
+# Release UI. Nerdbank.GitVersioning derives it from version.json plus commit height; creating
+# the release does not change it, and release.yml refuses a tag that disagrees with it.
+#
+# Run this on up-to-date main: the version belongs to the commit you are on.
+$ErrorActionPreference = 'Stop'
+Push-Location $PSScriptRoot
+try {
+    dotnet tool restore | Out-Null
+    $v = (dotnet tool run nbgv -- get-version --variable Version).Trim()
+    $tag = ($v.Split('.')[0..2]) -join '.'
+    $where = "$(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
+
+    Write-Output "commit           : $where"
+    Write-Output "computed version : $v"
+    Write-Output "release tag      : $tag"
+    Write-Output ""
+    Write-Output "Releases -> Draft a new release -> tag '$tag' -> publish; release.yml does the rest."
+    Write-Output "Note the tag is unprefixed - '$tag', not 'v$tag'."
+}
+finally { Pop-Location }

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Shows the version the current commit computes - i.e. the tag name to type into the GitHub
+# Release UI. Nerdbank.GitVersioning derives it from version.json plus commit height; creating
+# the release does not change it, and release.yml refuses a tag that disagrees with it.
+#
+# Run this on up-to-date main: the version belongs to the commit you are on.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+dotnet tool restore > /dev/null
+v=$(dotnet tool run nbgv -- get-version --variable Version | tr -d '[:space:]')
+tag=$(echo "$v" | cut -d. -f1-3)
+where="$(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
+
+echo "commit           : $where"
+echo "computed version : $v"
+echo "release tag      : $tag"
+echo ""
+echo "Releases -> Draft a new release -> tag '$tag' -> publish; release.yml does the rest."
+echo "Note the tag is unprefixed - '$tag', not 'v$tag'."


### PR DESCRIPTION
Ports `get-version.ps1` / `get-version.sh` from protobuf-net, plus the `.config/dotnet-tools.json` that pins `nbgv` (3.9.50, matching the `Nerdbank.GitVersioning` package version already in `Directory.Packages.props`).

They print what the current commit computes — i.e. the tag to type into the GitHub Release UI:

```
commit           : main @ 32e05b7
computed version : 1.3.5.13024
release tag      : 1.3.5

Releases -> Draft a new release -> tag '1.3.5' -> publish; release.yml does the rest.
Note the tag is unprefixed - '1.3.5', not 'v1.3.5'.
```

## Two adaptations for this repo

- **`version.json` is at the repository root here**, not under `src/`, so the `nbgv` call drops `--project src`. With the wrong path it silently computes a different version — exactly the failure a "check before you tag" script must not have.
- **The scripts say the tag is unprefixed.** This repo has always tagged `1.3.0`, `1.2.5` and so on, and `release.tagName` is `{version}`; a `v`-prefixed tag is precisely the mismatch that failed the 1.3.0 release.

## Why the tag comes from `Version` rather than `NuGetPackageVersion`

`release.yml`'s guard compares the tag against `NuGetPackageVersion`, so that would seem the obvious source — but on a branch it carries a `-g<commit>` suffix, whereas `Version` does not. Taking the first three components of `Version` therefore still prints the tag you would create once the commit is on `main`, which is more useful when you are checking ahead of time.

They agree where it counts — on `main`, which is where the script header tells you to run it:

| | |
| --- | --- |
| `Version` | `1.3.5.13024` |
| `NuGetPackageVersion` | `1.3.5` |
| scripts report | `1.3.5` |

Both scripts were run and produce identical output.
