### PR TITLE
docs: bring the AOT page up to date

### DIFF
--- a/docs/aot.md
+++ b/docs/aot.md
@@ -14,6 +14,10 @@ over may already have been removed.
 `protobuf-net.BuildTools` can build both at **compile time** instead, as ordinary C# in your own
 project — code you can read, step through, and that ILC can compile like anything else.
 
+This needs **protobuf-net.Grpc 1.3.6 or later**. Earlier versions statically root
+`RuntimeTypeModel.Default`, which keeps the whole reflection path reachable however static your own
+code is — on our own smoke test that difference is 100 trim warnings versus 4.
+
 ## Two halves, and you need both
 
 This is the part that catches people out, so it is worth stating plainly.
@@ -28,6 +32,9 @@ So you need:
 1. a **serializer model**, from protobuf-net's `[ProtoModel]` — see
    [the protobuf-net AOT documentation](https://docs.protobuf-net.dev/aot);
 2. a **gRPC model**, from `[ProtoGrpc]`, *pointed at that serializer model*.
+
+You do **not** have to populate the serializer model by hand, though — see
+[The payload types come for free](#the-payload-types-come-for-free).
 
 ## Opting in
 
@@ -56,6 +63,29 @@ protobuf-net's `[ProtoModel]`, so one entry does both halves:
 </PropertyGroup>
 ```
 
+If you want none of this — no analyzers, no generators, from either half — one property turns off
+everything `protobuf-net.BuildTools` does, and is checked before any work happens:
+
+``` xml
+<ProtoBufDisableBuildTools>true</ProtoBufDisableBuildTools>
+```
+
+## The payload types come for free
+
+`[ProtoService]` already names your contracts, so the serializer model does not need to be told about
+their request and response types a second time — they are added to it automatically. A `[ProtoModel]`
+that exists only to serve gRPC therefore needs no `[ProtoSerializable]` at all:
+
+``` c#
+[ProtoModel]
+public partial class MyModel : TypeModel { }        // that is the whole declaration
+```
+
+Add `[ProtoSerializable]` only for types you serialize directly yourself, outside gRPC.
+
+If the model lives in a **referenced assembly**, nothing can be added to it from here, so instead it is
+*checked*: any payload it has no serializer for is reported (`PBN4013`), naming the type and the model.
+
 ## Using it
 
 On the client, name the factory — that is what selects the generated proxy over the ref-emit one:
@@ -75,6 +105,47 @@ app.MapGrpcService<GreeterService>();
 `AddCodeFirstGrpc()` registers the reflection-based binder, so calling both would bind every
 operation twice. The generated method registers only what was generated.
 
+### Clients registered through dependency injection
+
+`AddCodeFirstGrpcClient<T>` does not take a factory — it resolves one from the container:
+
+``` c#
+services.AddSingleton<ClientFactory>(MyServices.Instance);   // once, anywhere in your setup
+services.AddCodeFirstGrpcClient<IGreeter>();                 // ...and every client uses it
+```
+
+The generated `AddMyServices()` does that registration for you, so a project that hosts services *and*
+consumes them needs nothing extra. A client-only project has no `AddMyServices()` to call, and is
+reminded with `PBN4017`.
+
+## Letting existing call sites stay as they are
+
+If you would rather not thread `MyServices.Instance` through every call, C# **interceptors** can do it
+for you. Opt in by naming the namespace the generated interceptors live in:
+
+``` xml
+<PropertyGroup>
+  <InterceptorsNamespaces>$(InterceptorsNamespaces);ProtoBuf.AOT</InterceptorsNamespaces>
+</PropertyGroup>
+```
+
+With that set, an ordinary call needs no change at all:
+
+``` c#
+var greeter = channel.CreateGrpcService<IGreeter>();    // rewritten to use MyServices.Instance
+```
+
+Worth knowing:
+
+- **it is opt-in because it has to be.** An interceptor in a namespace you have not enabled is a
+  compile *error* (`CS9137`), so nothing is generated unless you ask.
+- **it only ever swaps the factory argument.** The rewritten call is exactly
+  `(clientFactory ?? MyServices.Instance).CreateClient<TService>(client)` — the same thing you would
+  have written by hand, so there is no behaviour hiding in it.
+- **a call that already passes a factory is left alone.** Yours wins.
+- **without interceptors you get `PBN4016` instead**, with a code fix that inserts the argument. The
+  two produce the same program; the interceptor just saves you the edit.
+
 ## Diagnostics
 
 Anything the generator cannot handle is reported rather than guessed at, and everything it reports is
@@ -90,16 +161,40 @@ you want the model to be complete or the build to fail:
 | `PBN4000` | the language version is too low for build-time proxies |
 | `PBN4001` | the service interface is nested |
 | `PBN4002` | a method shape is not emitted at build time, so the contract is left to the runtime |
-| `PBN4003` | the service interface is generic |
+| `PBN4003` | the service interface is an **open** generic; a closed construction is fine |
 | `PBN4004` | a base interface is not marked `[SubService]` |
 | `PBN4005` | the `[ProtoGrpc]` type is not `partial` |
 | `PBN4006` | the `[ProtoGrpc]` type does not derive from `ClientFactory` |
 | `PBN4007` | a type named by `[ProtoService]` is not a service contract |
 | `PBN4008` | a named implementation does not implement its contract |
+| `PBN4009` | a contract declares no methods recognised as operations |
 | `PBN4010` | **no serializer model was named**, so payloads will be marshalled reflectively |
 | `PBN4011` | a named contract could not be resolved |
+| `PBN4012` | the named model is in this project but is not a `[ProtoModel]` |
+| `PBN4013` | a model in a *referenced* assembly has no serializer for a payload type |
+| `PBN4014` | the `[ProtoGrpc]` type is nested or generic |
+| `PBN4015` | this project publishes AOT or trimmed and has no `[ProtoGrpc]` at all |
+| `PBN4016` | a call is not using the proxies you have generated — **has a code fix** |
+| `PBN4017` | DI-registered clients are not using them — see [above](#clients-registered-through-dependency-injection) |
+| `PBN4018` | a contract was dropped, and under AOT that means calls on it will **throw** |
 
-`PBN4010` is the one to pay attention to: it is the "two halves" problem above.
+Two to pay particular attention to:
+
+- **`PBN4010`** is the "two halves" problem above.
+- **`PBN4018`** appears only when you have asked for AOT or trimming, and it is the difference between
+  "this contract falls back to reflection" and "this contract does not work". On a JIT build a dropped
+  contract really does keep working; under AOT there is no runtime proxy to fall back to.
+
+## What is supported
+
+The code-first surface protobuf-net.Grpc itself binds: unary, client-streaming, server-streaming and
+duplex operations; `CallContext` or `CancellationToken`; void requests and responses; `[SubService]`
+bases; `IDisposable`/`IAsyncDisposable`; `[Operation]` naming and the WCF
+`[ServiceContract]`/`[OperationContract]` equivalents; and closed generic contracts.
+
+Shapes that stay on the runtime path — `IObservable<T>`, `Stream`, `Grpc.Core`'s own call types, a base
+interface that is not `[SubService]` — are each reported, and under AOT that report is `PBN4018`:
+there is no runtime path there, so those contracts will throw rather than degrade.
 
 ## Checking it really works
 
@@ -112,3 +207,7 @@ dotnet publish -c Release -r win-x64
 
 `<PublishAot>true</PublishAot>` also enables trim/AOT analysis at ordinary *build* time, so you can
 see the warnings without paying for a native publish.
+
+For what it is worth, that is how this is tested: a real client and a real server, over a real socket,
+in a single natively-compiled binary, exercising all five operation shapes plus interception — because
+a JIT run cannot tell you whether any of this actually works.


### PR DESCRIPTION
Brings `docs/aot.md` up to date with the build-time proxy work. Documentation only — no code changes.

## One correction

`PBN4003` was described as "the service interface is generic". It is **open** generics only: a closed
construction like `IBox<Request>` is emitted like any other contract. As written, the table steered people
away from a pattern that works.

## Additions

Roughly in order of how much time each saves a reader:

- **Seeding.** The page implied you populate the `[ProtoModel]` yourself. You don't — `[ProtoService]`
  already names the contracts, so their request and response types are added automatically, and a model
  that exists only to serve gRPC needs **no `[ProtoSerializable]` at all**. Also covers the
  referenced-assembly case, where nothing can be added and `PBN4013` checks instead.
- **Interceptors**, which were absent entirely: the `<InterceptorsNamespaces>` opt-in, the fact that
  existing `CreateGrpcService` calls then need no edit, that it is opt-in *because* `CS9137` is an error,
  and that the rewrite only ever swaps the factory argument — so there is no behaviour hiding in it.
- **DI-registered clients.** `AddCodeFirstGrpcClient<T>` resolves its factory from the container, so
  nothing else on the page applied to it. The generated `AddMyServices()` now does that registration, and
  `PBN4017` covers the client-only project that has no `AddMyServices()` to call.
- **Eight missing diagnostics** — `PBN4009` and `PBN4012`–`PBN4018`. Two are called out specifically:
  `PBN4016` has a code fix, and `PBN4018` is the difference between "this contract falls back to
  reflection" and "this contract does not work", since under AOT there is no runtime path to fall back to.
- **The 1.3.6 floor.** Earlier versions statically root `RuntimeTypeModel.Default`, which keeps the whole
  reflection path reachable however static the generated code is — on the smoke test that is the
  difference between 100 trim warnings and 4.
- **A "what is supported" section**, and `ProtoBufDisableBuildTools` — which was only documented on
  protobuf-net's side, even though this page is where a gRPC reader looks for it.

Also says what "checking it really works" means in practice, because a real client and a real server over
a real socket in one natively-compiled binary is a stronger claim than "publish and run", and the reader
may as well know which one is on offer.

The protobuf-net side now links here from its own AOT page, so the two halves cross-reference rather than
duplicating each other.
