### PR TITLE
Give each package a readme and real metadata, and fix the docs links

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <RepositoryUrl>https://github.com/protobuf-net/protobuf-net.Grpc</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <Product>protobuf-net.Grpc ($(TargetFramework))</Product>
-        <PackageReleaseNotes>https://protobuf-net.github.io/protobuf-net.Grpc/releasenotes#$(VersionPrefix)</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/protobuf-net/protobuf-net.Grpc/releases</PackageReleaseNotes>
 
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <PackageTags>grpc</PackageTags>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 - [Register Client Service in Startup.cs](registerClientService)
 - [.NET Streams](streams)
 - [Native AOT and trimming](aot) (preview)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)
 
 Other Content
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,21 +1,37 @@
 # Package/Project Layout
 
-protobuf-net.Grpc is split over several projects:
+protobuf-net.Grpc is split over several packages; you generally reference the one that matches how you are
+hosting or consuming the service.
 
 ## `protobuf-net.Grpc`
 
-You will not usually reference this directly. This is the shared core and contains all the code that isn't tied to a specific client/server implementation,
-and it targets all runtimes. It does not have any expensive downstream dependencies and is entirely managed. It contains all of the code related to clients (both
-the managed and unmanaged client APIs share a common `ChannelBase` abstraction).
+The shared core: everything that is not tied to a specific client/server implementation. It targets all
+runtimes, is entirely managed, and has no expensive downstream dependencies. All the client-side code lives
+here — the managed and unmanaged client APIs share a common `ChannelBase` abstraction — so a client over
+`Grpc.Net.Client` needs only this package.
 
 ## `protobuf-net.Grpc.AspNetCore`
 
-This is for using gRPC as a **server** with the ASP.NET Core 3.1 implementation. It takes a dependency on `Grpc.AspNetCore.Server` and `Microsoft.AspNetCore.App`
-(although you'll already have the latter if you're hosting in ASP.NET Core). It only works on .NET Core 3.1 (or above).
+For using gRPC as a **server** on ASP.NET Core. It takes a dependency on `Grpc.AspNetCore.Server` and
+`Microsoft.AspNetCore.App` (which you already have if you are hosting in ASP.NET Core).
+
+## `protobuf-net.Grpc.ClientFactory`
+
+For resolving **clients** from dependency injection, on top of `Grpc.Net.ClientFactory`: the service contract
+interface becomes injectable, with `HttpClientFactory`'s handler lifetime and logging applied to it.
+
+## `protobuf-net.Grpc.Reflection`
+
+Generates `.proto` schemas from code-first contracts, and implements the gRPC reflection service over them.
+Useful on its own for producing a schema to hand to callers on other platforms.
+
+## `protobuf-net.Grpc.AspNetCore.Reflection`
+
+Wires the above into ASP.NET Core endpoint routing, so tools such as `grpcurl` can discover the services a
+code-first host exposes.
 
 ## `protobuf-net.Grpc.Native`
 
-This is for using gRPC as a **client or server** using the unmanaged/native binaries via `Grpc.Core` (specifically, the `Channel` API).
-Like `protobuf-net.Grpc`, it works on .NET Standard 2.0 or .NET Framework 4.6.1 (or above).
-
-(caveat: server API not yet implemented for `protobuf-net.Grpc.Native`)
+For using gRPC as a **client or server** over the unmanaged/native binaries via `Grpc.Core` (specifically,
+the `Channel` API). Like `protobuf-net.Grpc`, it works on .NET Standard 2.0 and .NET Framework. `Grpc.Core`
+itself is in maintenance, so prefer the managed stack where that is an option.

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+**[The GitHub releases page](https://github.com/protobuf-net/protobuf-net.Grpc/releases) is the primary
+source of release notes** — that is where each release is described, as it happens. The notes below remain
+as the history up to 1.2.2.
+
 ## unreleased
 
 ## 1.2.2

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,12 @@ if you prefer: there are [various configuration options](https://grpc.protobuf-n
 
 Everything is available as pre-built packages on nuget; in particular, you probably want one of:
 
-- [`protobuf-net.Grpc.AspNetCore`](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore) for servers using ASP.NET Core 3.1
+- [`protobuf-net.Grpc.AspNetCore`](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore) for servers using ASP.NET Core
+- [`protobuf-net.Grpc.ClientFactory`](https://www.nuget.org/packages/protobuf-net.Grpc.ClientFactory) for clients resolved from dependency injection
+- [`protobuf-net.Grpc`](https://www.nuget.org/packages/protobuf-net.Grpc) and [`Grpc.Net.Client`](https://www.nuget.org/packages/Grpc.Net.Client/) for clients using `HttpClient`
 - [`protobuf-net.Grpc.Native`](https://www.nuget.org/packages/protobuf-net.Grpc.Native) for clients or servers using the native/unmanaged API
-- [`protobuf-net.Grpc`](https://www.nuget.org/packages/protobuf-net.Grpc) and [`Grpc.Net.Client`](https://www.nuget.org/packages/Grpc.Net.Client/) for clients using `HttpClient` on .NET Core 3.1
+
+[What each package is for](https://grpc.protobuf-net.dev/projects).
 
 [Usage examples are available in C#, VB and F#](https://github.com/protobuf-net/protobuf-net.Grpc/tree/main/examples/pb-net-grpc).
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,11 +2,20 @@
   <Import Project="../Directory.Build.props" />
   <PropertyGroup>
     <PackageIcon>protobuf-net.png</PackageIcon>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <!-- the readme is included explicitly below; pack reads its items from the OUTER build of a
+         multi-targeting project, where the SDK's default item globs do not run, so the glob must
+         not be the only thing that finds it - and must not claim it twice -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);readme.md</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../protobuf-net.png">
         <Pack>True</Pack>
         <PackagePath></PackagePath>
     </None>
+    <!-- each package carries its own readme.md - it is what nuget.org shows on the package page,
+         so it should describe THAT package; anything without one falls back to the repo readme -->
+    <None Include="readme.md" Pack="true" PackagePath="/" Condition="Exists('$(MSBuildProjectDirectory)/readme.md')" />
+    <None Include="../../readme.md" Link="readme.md" Pack="true" PackagePath="/" Visible="false" Condition="!Exists('$(MSBuildProjectDirectory)/readme.md')" />
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore.Reflection/protobuf-net.Grpc.AspNetCore.Reflection.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server.Reflection</RootNamespace>
+    <Title>protobuf-net.Grpc.AspNetCore.Reflection</Title>
+    <Description>gRPC server reflection for code-first services hosted in ASP.NET Core</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.Grpc.AspNetCore.Reflection/readme.md
+++ b/src/protobuf-net.Grpc.AspNetCore.Reflection/readme.md
@@ -1,0 +1,21 @@
+# protobuf-net.Grpc.AspNetCore.Reflection
+
+Adds the standard gRPC server reflection service to an ASP.NET Core host running
+[code-first gRPC](https://grpc.protobuf-net.dev/) services, so tools like `grpcurl` and Postman can discover
+the services and their schemas — which code-first services would otherwise not publish anywhere.
+
+```csharp
+builder.Services.AddCodeFirstGrpcReflection();
+// ...
+app.MapCodeFirstGrpcReflectionService();
+```
+
+The schemas are generated from the contracts by
+[protobuf-net.Grpc.Reflection](https://www.nuget.org/packages/protobuf-net.Grpc.Reflection); nothing needs to
+be written by hand or checked in.
+
+## More
+
+- [Creating a proto file](https://grpc.protobuf-net.dev/createProtoFile)
+- [Getting started](https://grpc.protobuf-net.dev/gettingstarted)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)

--- a/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
+++ b/src/protobuf-net.Grpc.AspNetCore/protobuf-net.Grpc.AspNetCore.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.Server</RootNamespace>
+    <Title>protobuf-net.Grpc.AspNetCore</Title>
+    <Description>Hosts code-first gRPC services in ASP.NET Core</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.Grpc.AspNetCore/readme.md
+++ b/src/protobuf-net.Grpc.AspNetCore/readme.md
@@ -1,0 +1,27 @@
+# protobuf-net.Grpc.AspNetCore
+
+Hosts [code-first gRPC](https://grpc.protobuf-net.dev/) services in ASP.NET Core: your service is a class
+implementing a `[ServiceContract]` interface, with no `.proto` file and no generated base class.
+
+```csharp
+builder.Services.AddCodeFirstGrpc();
+// ...
+app.MapGrpcService<MyService>();
+```
+
+```csharp
+public class MyService : IMyAmazingService
+{
+    public ValueTask<SearchResponse> SearchAsync(SearchRequest request) { /* ... */ }
+}
+```
+
+Everything else is ordinary `Grpc.AspNetCore.Server` — interceptors, health checks, logging and the rest all
+apply unchanged. For a `.proto` schema, or gRPC server reflection, add
+[protobuf-net.Grpc.AspNetCore.Reflection](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore.Reflection).
+
+## More
+
+- [Getting started](https://grpc.protobuf-net.dev/gettingstarted)
+- [Configuration options](https://grpc.protobuf-net.dev/configuration)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)

--- a/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
+++ b/src/protobuf-net.Grpc.ClientFactory/protobuf-net.Grpc.ClientFactory.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc.ClientFactory</RootNamespace>
+    <Title>protobuf-net.Grpc.ClientFactory</Title>
+    <Description>Code-first gRPC clients for dependency injection, via HttpClientFactory</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.Grpc.ClientFactory/readme.md
+++ b/src/protobuf-net.Grpc.ClientFactory/readme.md
@@ -1,28 +1,44 @@
-`protobuf-net.Grpc.ClientFactory` allows accessing clients in a standard .NET dependency-injection mechanism.
+# protobuf-net.Grpc.ClientFactory
 
-Core APIs:
+Registers [code-first gRPC](https://grpc.protobuf-net.dev/) clients with dependency injection, on top of
+`Grpc.Net.ClientFactory` — so the service contract interface is injectable, and gets `HttpClientFactory`'s
+handler lifetime, logging and resilience along with it.
 
-``` csharp
-services.AddCodeFirstGrpcClient<IMyService>(...);
+```csharp
+builder.Services.AddCodeFirstGrpcClient<IMyAmazingService>(options =>
+{
+    options.Address = new Uri("https://localhost:5001");
+});
 ```
 
-This works like the inbuilt [`AddGrpcClient<T>(...)` API](https://learn.microsoft.com/aspnet/core/grpc/clientfactory),
-but additionally configures the gRPC service for use with protobuf-net.Grpc's code-first style. In addition to
-other APIs, this allows the `GrpcClientFactory` API to be injected to provide access to services.
+This works like the built-in
+[`AddGrpcClient<T>(...)`](https://learn.microsoft.com/aspnet/core/grpc/clientfactory), but additionally
+configures the service for protobuf-net.Grpc's code-first style. Then take a dependency on the contract
+itself — or on `GrpcClientFactory`, to resolve services yourself:
 
-By default, this uses the default/shared configuration. If you wish to use a bespoke protobuf-net configuration,
-additional services can be injected into the service provider. For *servers*, the `BinderConfiguration` is the primary
-API to inject for additional configuration. For *clients*, the `ClientFactory` is the most important. You
-can (if you wish) unify this by providing both:
+```csharp
+public class MyController(IMyAmazingService service) { /* ... */ }
+```
 
-``` c#
-var model = RuntimeTypeModel.Create(); // custom model
-// not shown: configure protobuf-net model
+`ConfigureCodeFirstGrpcClient<T>` does the same for a client builder you already have.
 
-// prepare a custom protobuf-net.Grpc configuration using that model
+## Using a custom protobuf-net model
+
+The default/shared configuration is used unless you register your own. For *clients* the key service is
+`ClientFactory`; for *servers* it is `BinderConfiguration`. Both can come from one model:
+
+```csharp
+var model = RuntimeTypeModel.Create(); // configure the protobuf-net model as needed
+
 var marshallerFactory = ProtoBufMarshallerFactory.Create(model, ProtoBufMarshallerFactory.Options.None);
 var binderConfiguration = BinderConfiguration.Create([marshallerFactory]);
 
-// register server and client overrides
-services.AddSingleton(binderConfiguration).AddSingleton(ClientFactory.Create(binderConfiguration));
+services.AddSingleton(binderConfiguration)
+        .AddSingleton(ClientFactory.Create(binderConfiguration));
 ```
+
+## More
+
+- [Registering a client service](https://grpc.protobuf-net.dev/registerClientService)
+- [Configuration options](https://grpc.protobuf-net.dev/configuration)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)

--- a/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
+++ b/src/protobuf-net.Grpc.Native/protobuf-net.Grpc.Native.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.Grpc</RootNamespace>
+    <Title>protobuf-net.Grpc.Native</Title>
+    <Description>Code-first gRPC over the unmanaged Grpc.Core API</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Core" />

--- a/src/protobuf-net.Grpc.Native/readme.md
+++ b/src/protobuf-net.Grpc.Native/readme.md
@@ -1,0 +1,28 @@
+# protobuf-net.Grpc.Native
+
+[Code-first gRPC](https://grpc.protobuf-net.dev/) over the unmanaged `Grpc.Core` API, for clients and servers
+that cannot use the fully managed `Grpc.Net.Client` / `Grpc.AspNetCore.Server` stack — .NET Framework, or
+anything else still on the native binaries.
+
+```csharp
+var channel = new Channel("localhost", 5001, ChannelCredentials.Insecure);
+var client = channel.CreateGrpcService<IMyAmazingService>();
+var results = await client.SearchAsync(request);
+```
+
+A server binds an implementation to the service definitions:
+
+```csharp
+var server = new Server();
+server.Services.AddCodeFirst(new MyService());
+```
+
+`Grpc.Core` itself is in maintenance; where the managed stack is an option, prefer
+[protobuf-net.Grpc](https://www.nuget.org/packages/protobuf-net.Grpc) and
+[protobuf-net.Grpc.AspNetCore](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore).
+
+## More
+
+- [Getting started](https://grpc.protobuf-net.dev/gettingstarted)
+- [Package layout](https://grpc.protobuf-net.dev/projects)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)

--- a/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
+++ b/src/protobuf-net.Grpc.Reflection/protobuf-net.Grpc.Reflection.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFrameworks>net472;netstandard2.1;netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <RootNamespace>ProtoBuf.Grpc.Reflection</RootNamespace>
+        <Title>protobuf-net.Grpc.Reflection</Title>
+        <Description>Generates .proto schemas from code-first gRPC contracts, and implements the gRPC reflection service</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protobuf-net.Grpc.Reflection/readme.md
+++ b/src/protobuf-net.Grpc.Reflection/readme.md
@@ -1,0 +1,19 @@
+# protobuf-net.Grpc.Reflection
+
+Produces `.proto` schemas from [code-first gRPC](https://grpc.protobuf-net.dev/) contracts, so a code-first
+service can still hand callers on other platforms the schema they need:
+
+```csharp
+var schema = new SchemaGenerator().GetSchema<IMyAmazingService>();
+```
+
+It also implements the standard gRPC server reflection service over those generated descriptors. To expose
+that from an ASP.NET Core host, use
+[protobuf-net.Grpc.AspNetCore.Reflection](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore.Reflection),
+which wires it into the endpoint routing for you.
+
+## More
+
+- [Creating a proto file](https://grpc.protobuf-net.dev/createProtoFile)
+- [Documentation](https://grpc.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)

--- a/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
+++ b/src/protobuf-net.Grpc/protobuf-net.Grpc.csproj
@@ -2,6 +2,8 @@
     <PropertyGroup>
         <TargetFrameworks>net472;netstandard2.1;netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <RootNamespace>ProtoBuf.Grpc</RootNamespace>
+        <Title>protobuf-net.Grpc</Title>
+        <Description>Code-first gRPC for .NET: declare services as .NET interfaces, with no .proto file and no generated client; shared core for clients and servers</Description>
         <DefineConstants>$(DefineConstants);PLAT_NO_CHANNEL_READALLASYNC</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/src/protobuf-net.Grpc/readme.md
+++ b/src/protobuf-net.Grpc/readme.md
@@ -1,0 +1,36 @@
+# protobuf-net.Grpc
+
+Code-first gRPC for .NET: describe the service as an interface, implement it, and consume it — no `.proto`
+file and no generated client in between.
+
+```csharp
+[ServiceContract]
+public interface IMyAmazingService
+{
+    ValueTask<SearchResponse> SearchAsync(SearchRequest request);
+}
+```
+
+The server implements that interface; the client asks for it:
+
+```csharp
+var client = http.CreateGrpcService<IMyAmazingService>();
+var results = await client.SearchAsync(request);
+```
+
+The messages are ordinary [protobuf-net](https://www.nuget.org/packages/protobuf-net) contracts, so the wire
+format is plain protobuf and other gRPC implementations can talk to it — with a `.proto` schema generated on
+demand if they need one.
+
+This package is the shared core, and is what a **client** over `Grpc.Net.Client` needs. Most other scenarios
+want one of:
+
+- [protobuf-net.Grpc.AspNetCore](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore) — servers on ASP.NET Core
+- [protobuf-net.Grpc.ClientFactory](https://www.nuget.org/packages/protobuf-net.Grpc.ClientFactory) — clients via dependency injection
+- [protobuf-net.Grpc.Native](https://www.nuget.org/packages/protobuf-net.Grpc.Native) — the unmanaged `Grpc.Core` API
+
+## More
+
+- [Getting started](https://grpc.protobuf-net.dev/gettingstarted)
+- [Documentation](https://grpc.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net.Grpc/releases)


### PR DESCRIPTION
All six packages published with the literal description "Package Description", no title, and no readme at all — so nuget.org had nothing to show beyond the package id. Each project now carries a `readme.md` describing that package: what it is, the snippet that gets you going, and which sibling package you probably wanted instead.

Deliberately short; the longer material stays on [grpc.protobuf-net.dev](https://grpc.protobuf-net.dev/), which each readme links to.

The wiring is in `src/Directory.Build.props` rather than `.targets` because pack reads its items from the **outer** build of a multi-targeting project, where the SDK's default item globs do not run — a `<None Update>` against the glob silently packs nothing and fails as NU5039. Hence the explicit `Include` plus a `DefaultItemExcludes` entry so the glob does not also claim the file.

`protobuf-net.Grpc.ClientFactory` already had a readme that nothing packed; its custom-model section carries over into the new one.

Also:

- **Release notes** pointed at `protobuf-net.github.io`, which we no longer publish to, and at a per-version anchor in a file we stopped updating. They now point at the [releases page](https://github.com/protobuf-net/protobuf-net.Grpc/releases), and `docs/releasenotes.md` says as much at the top.
- **`docs/projects.md`** described three of the six packages and dated the ASP.NET Core one to 3.1; it now covers all six. Its "server API not yet implemented" caveat on the native package was stale too — `AddCodeFirst` binds a server there, as `examples/pb-grpc/Server_CS` does.
- The package list in the repo readme picked up `ClientFactory` and lost its 3.1 references.

Verified by `dotnet build` + `dotnet pack --no-build` over `Build.csproj` and reading back the nuspecs: all six carry their own readme, a title, and a real description.