### PR TITLE
Package validation: diff each package against 1.3.14 at pack time

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,3 +30,7 @@ jobs:
       run: dotnet build Build.csproj --no-restore -c Release /p:CI=true /p:GeneratePackageOnBuild=false
     - name: Test
       run: dotnet test Build.csproj --no-build -c Release /p:CI=true --verbosity normal
+    # pack is what runs package validation; without a pack in PR CI it would only run at
+    # release time, which is far too late for it to stop anything
+    - name: Pack (runs package validation)
+      run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:CI=true /p:PackageOutputPath=${{ github.workspace }}\.nupkgs

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <PackageIcon>protobuf-net.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <!-- ApiCompat, as built into the SDK: at pack time this downloads the baseline version of each
+         package from nuget.org and diffs the surface, so a removed member or a narrowed signature
+         fails the build (CP0001/CP0002/CP0003) instead of shipping. It also cross-checks that a
+         consumer resolving the netstandard2.0 asset gets something compatible with the net8.0 one.
+         All six packages are on the same version, so one baseline covers them. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.3.14</PackageValidationBaselineVersion>
     <!-- the readme is included explicitly below; pack reads its items from the OUTER build of a
          multi-targeting project, where the SDK's default item globs do not run, so the glob must
          not be the only thing that finds it - and must not claim it twice -->


### PR DESCRIPTION
`EnablePackageValidation` is **ApiCompat**, as built into the SDK. At pack time it pulls the baseline version of each package from nuget.org and diffs the surface, so removing a public member or narrowing a signature fails the build with `CP0001`/`CP0002`/`CP0003` rather than shipping. It also cross-checks that a consumer resolving the `netstandard2.0` asset gets something compatible with the `net8.0` one.

All six packages are on exactly **1.3.14**, so a single baseline in `src/Directory.Build.props` covers the lot.

### Why this as well as the public API files

They catch different things, and neither subsumes the other:

| | catches | when |
| --- | --- | --- |
| `PublicAPI.*.txt` | source-level API drift, in our own build | compile |
| package validation | binary and package drift vs **what is actually published** | pack |

A member can be added to `PublicAPI.Shipped.txt` in the same commit that removes it from the package; only this notices.

### CI packs now

Pack is what runs the validation, so without a pack step in PR CI it would run only in `release.yml` — after the change had been merged and tagged, which is far too late to stop anything. Test still runs first, so a test failure reports before an API one.

### Verified able to fail

Not merely observed passing. Making one `ServiceDefinitionCollectionExtensions.AddCodeFirst` overload `internal` produces:

```
error CP0002: Member 'int ProtoBuf.Grpc.Server.ServiceDefinitionCollectionExtensions.AddCodeFirst<TService>(
  Grpc.Core.Server.ServiceDefinitionCollection, TService, BinderConfiguration?, TextWriter?)'
  exists on [Baseline] lib/net10.0/protobuf-net.Grpc.Native.dll but not on lib/net10.0/protobuf-net.Grpc.Native.dll
```

— an error, not a warning, on all four of that package's target frameworks. As they stand, all six packages pack clean.