### PR TITLE
Shipping hygiene: security policy, Dependabot, SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Two ecosystems, for two different reasons.
+#
+# nuget: keeps the referenced packages current, and - more to the point - surfaces a security
+# advisory against something we depend on as a PR rather than as something someone has to notice.
+# Central package management means the versions all live in Directory.Packages.props, which
+# Dependabot understands.
+#
+# github-actions: the workflows pin actions by commit SHA (see the note in each), and a SHA does
+# not float. Dependabot is what moves those pins, rewriting the SHA and the trailing version
+# comment together. Without this, pinning would simply mean never updating.
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # one PR per family rather than one per package; these move together anyway
+      grpc:
+        patterns: [ "Grpc*" ]
+      microsoft:
+        patterns: [ "Microsoft.*", "System.*" ]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@
 # the guard step below fails the run on any mismatch rather than publishing a package that disagrees
 # with its release.
 
+# Actions are pinned by commit SHA rather than by tag. A tag is mutable: whoever controls the
+# action repository can repoint v4 at different code, and this workflow holds id-token: write and
+# publishes to nuget.org, so that is the one place in either repo where it genuinely matters. The
+# trailing comment records which release the SHA is, and Dependabot moves both together.
 name: Release
 
 on:
@@ -33,11 +37,11 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
           8.0.x
@@ -65,13 +69,13 @@ jobs:
       run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:CI=true /p:PackageOutputPath=${{ github.workspace }}\.nupkgs
     # The packages survive as a run artifact even if the push fails
     - name: Upload packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: packages
         path: .nupkgs/*.nupkg
     - name: NuGet login (OIDC to temp API key)
       if: github.event_name == 'release'
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting instead:
+<https://github.com/protobuf-net/protobuf-net.Grpc/security/advisories/new>. That opens a private
+thread visible only to the maintainers, and is the fastest route to a fix and an advisory.
+
+If that is unavailable to you for any reason, email <marc.gravell@gmail.com> with `protobuf-net.Grpc
+security` in the subject.
+
+Please include enough to reproduce: the package and version, the target framework, and a minimal
+service contract or payload that shows the problem.
+
+## What is in scope
+
+This repository is code-first gRPC for .NET: it turns .NET interfaces into gRPC services, and moves
+payloads through protobuf-net. The things worth reporting are broadly:
+
+- a payload that causes unbounded allocation, non-terminating work, or a crash while being
+  marshalled or unmarshalled;
+- a service binding that exposes more than the contract declares - a method reachable that should
+  not be, or endpoint metadata (`[Authorize]` and friends) not carried onto the endpoint;
+- anything that lets a client influence server state outside the declared contract.
+
+Serialization of *untrusted* input is the interesting surface. Note that protobuf-net itself is a
+separate repository - <https://github.com/protobuf-net/protobuf-net> - and a problem in the
+serializer proper belongs there; if you are unsure which, report it here and it will be moved.
+
+## Supported versions
+
+Fixes land on `main` and ship in the next release of the affected package. There is no long-term
+servicing branch, so "supported" means the current release line.


### PR DESCRIPTION
Three gaps that have nothing to do with the code and everything to do with being a package other people depend on.

### `SECURITY.md`

There is currently no documented private channel for reporting a vulnerability here — the only route on offer is a public issue, which is the wrong one. This points at GitHub's private vulnerability reporting with an email fallback, and says what is actually worth reporting: payloads that misbehave while being marshalled, bindings that expose more than the contract declares, and endpoint metadata (the `[Authorize]` family) not reaching the endpoint. It also notes that the serializer proper lives in the other repository, since that is an easy wrong tracker to land on.

> **The file is only half of it.** Private vulnerability reporting is a repository *setting* and is currently off, so the advisory link in this file 404s until it is switched on (Settings → Code security → Private vulnerability reporting).

### `.github/dependabot.yml`

Two ecosystems, for two different reasons:

- **nuget** — so an advisory against something we depend on arrives as a PR rather than as something someone has to notice. Central package management means the versions live in one file, which Dependabot understands. Grouped by family so it is a few PRs, not thirty.
- **github-actions** — because of the third change below.

### SHA-pinned actions

A tag is mutable: whoever controls the action repository can repoint `v4` at different code. `release.yml` holds `id-token: write` and publishes to nuget.org, so this is the one workflow where it genuinely matters.

| action | was | now |
| --- | --- | --- |
| actions/checkout | `v4` | `11d5960…` (v4.4.0) |
| actions/setup-dotnet | `v4` | `67a3573…` (v4.3.1) |
| actions/upload-artifact | `v4` | `ea165f8…` (v4.6.2) |
| NuGet/login | `v1` | `8d19675…` (v1.2.0) |

**This is a pin, not an upgrade** — the SHAs are what `v4`/`v1` point at today (checkout is on v7 upstream; that is deliberately not adopted here). Each carries a trailing comment naming the release, and Dependabot rewrites the SHA and the comment together. Without that, pinning would just mean never updating.