### PR TITLE
Point the package project URL at the site

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,10 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ProtoBuf.snk</AssemblyOriginatorKeyFile>
         <Copyright>Marc Gravell, 2019-</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/protobuf-net/protobuf-net.Grpc</PackageProjectUrl>
+        <!-- the project's home, not its source: RepositoryUrl below already carries the repo,
+             and nuget.org renders the two as separate links - pointing both at GitHub spends
+             the "Project website" slot on a duplicate -->
+        <PackageProjectUrl>https://grpc.protobuf-net.dev</PackageProjectUrl>
         <RepositoryUrl>https://github.com/protobuf-net/protobuf-net.Grpc</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <Product>protobuf-net.Grpc ($(TargetFramework))</Product>


### PR DESCRIPTION
`PackageProjectUrl` and `RepositoryUrl` were both `https://github.com/protobuf-net/protobuf-net.Grpc`, so nuget.org rendered **"Project website" and "Source repository" as the same link** — the project website slot was spent on a duplicate of something already there, and nothing in the package metadata pointed at the docs.

grpc.protobuf-net.dev goes in the first; the repo stays in the second.

Confirmed in a real packed nuspec rather than assumed:

```xml
<projectUrl>https://grpc.protobuf-net.dev/</projectUrl>
<repository type="git" url="https://github.com/protobuf-net/protobuf-net.Grpc" commit="c92f7452..." />
```

Two things worth knowing:

- It is a shared property in `Directory.Build.props`, so this moves `.AspNetCore`, `.ClientFactory`, `.Native` and `.Reflection` along with it. That is the intent — they are all the same project — but it is wider than the one package.
- Published packages are immutable, so this shows up from the next release onward and does nothing for 1.3.14 and earlier.

The readme already links grpc.protobuf-net.dev, so the docs were reachable from the page body; this just stops the metadata link being a duplicate.
